### PR TITLE
kafka : Connect early and reuse Client

### DIFF
--- a/kafka/integration_test.go
+++ b/kafka/integration_test.go
@@ -36,19 +36,28 @@ type testServer struct {
 }
 
 func (ks *testServer) NewConsumer(topic string, groupID string) substrate.AsyncMessageSource {
-	return &AsyncMessageSource{
+	s, err := NewAsyncMessageSource(AsyncMessageSourceConfig{
 		Brokers:       []string{fmt.Sprintf("localhost:%d", ks.port)},
 		ConsumerGroup: groupID,
 		Topic:         topic,
 		Offset:        OffsetOldest,
+	})
+
+	if err != nil {
+		panic(err)
 	}
+	return s
 }
 
 func (ks *testServer) NewProducer(topic string) substrate.AsyncMessageSink {
-	return &AsyncMessageSink{
+	s, err := NewAsyncMessageSink(AsyncMessageSinkConfig{
 		Brokers: []string{fmt.Sprintf("localhost:%d", ks.port)},
 		Topic:   topic,
+	})
+	if err != nil {
+		panic(err)
 	}
+	return s
 }
 
 func (ks *testServer) Kill() error {

--- a/kafka/status.go
+++ b/kafka/status.go
@@ -5,15 +5,9 @@ import (
 	"github.com/uw-labs/substrate"
 )
 
-func status(brokerAddrs []string, topic string) (*substrate.Status, error) {
+func status(client sarama.Client, topic string) (*substrate.Status, error) {
 
 	status := &substrate.Status{}
-
-	client, err := sarama.NewClient(brokerAddrs, sarama.NewConfig())
-	if err != nil {
-		return nil, err
-	}
-	defer client.Close()
 
 	writablePartitions, err := client.WritablePartitions(topic)
 	if err != nil {


### PR DESCRIPTION
With Kafka, for both consumer and producers, introduce a new constructor
function, and establish a client connection to the broker(s)
immediately.  We use this client in the main consume & produce methods,
but also use the same client in the status call, to ensure we're
checking the actual client connection in use.