### PR TITLE
Use consistent naming

### DIFF
--- a/sync_adapter_sink_test.go
+++ b/sync_adapter_sink_test.go
@@ -63,6 +63,6 @@ func (mock *mockAsyncSink) Close() error {
 	return nil
 }
 
-func (m *mockAsyncSink) Status() (*Status, error) {
+func (mock *mockAsyncSink) Status() (*Status, error) {
 	return &Status{Working: true}, nil
 }

--- a/sync_adapter_source_test.go
+++ b/sync_adapter_source_test.go
@@ -121,19 +121,19 @@ type mockAsyncSource struct {
 	closed chan struct{}
 }
 
-func (m *mockAsyncSource) ConsumeMessages(ctx context.Context, messages chan<- Message, acks <-chan Message) error {
+func (mock *mockAsyncSource) ConsumeMessages(ctx context.Context, messages chan<- Message, acks <-chan Message) error {
 	for {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case msg := <-m.toSend:
+		case msg := <-mock.toSend:
 			select {
 			case messages <- msg:
 				select {
 				case <-ctx.Done():
 					return ctx.Err()
 				case ack := <-acks:
-					m.acked <- ack
+					mock.acked <- ack
 				}
 			case <-ctx.Done():
 				return ctx.Err()
@@ -147,6 +147,6 @@ func (mock *mockAsyncSource) Close() error {
 	return nil
 }
 
-func (m *mockAsyncSource) Status() (*Status, error) {
+func (mock *mockAsyncSource) Status() (*Status, error) {
 	return &Status{Working: true}, nil
 }


### PR DESCRIPTION
Use the same variable name for the receiver.