### PR TITLE
Pass context.Context to consumer callback

### DIFF
--- a/substrate.go
+++ b/substrate.go
@@ -41,7 +41,7 @@ type AsyncMessageSource interface {
 
 // ConsumerMessageHandler is the callback function type that synchronous
 // message consumers must implement.
-type ConsumerMessageHandler func(Message) error
+type ConsumerMessageHandler func(context.Context, Message) error
 
 // SynchronousMessageSource represents a message source that allows "message
 // at a time" consumption and relieves the consumer from having to deal with

--- a/sync_adapter_source.go
+++ b/sync_adapter_source.go
@@ -37,7 +37,7 @@ func (a *synchronousMessageSourceAdapter) ConsumeMessages(ctx context.Context, h
 	for {
 		select {
 		case msg := <-messages:
-			if err := handler(msg); err != nil {
+			if err := handler(ctx, msg); err != nil {
 				cancel()
 				<-errs
 				return err

--- a/sync_adapter_source_test.go
+++ b/sync_adapter_source_test.go
@@ -31,7 +31,7 @@ func TestSyncConsumeAdapterBasic(t *testing.T) {
 	defer cancel()
 
 	var rcvd []Message
-	cb := func(m Message) error {
+	cb := func(ctx context.Context, m Message) error {
 		rcvd = append(rcvd, m)
 		return nil
 	}
@@ -86,7 +86,7 @@ func TestSyncConsumeAdapterNoAckAfterError(t *testing.T) {
 
 	errOn3rd := errors.New("error on 3rd message")
 
-	cb := func(m Message) error {
+	cb := func(ctx context.Context, m Message) error {
 		if m.(*message) == m3 {
 			return errOn3rd
 		}


### PR DESCRIPTION
This changes the synchronous consumer callback function to additionally
take a context.Context so that handling can be interrupted.

Note that this represents an API change.