### PR TITLE
Export config values for nats streaming source

### DIFF
--- a/natsstreaming/integration_test.go
+++ b/natsstreaming/integration_test.go
@@ -36,11 +36,11 @@ type testServer struct {
 
 func (ks *testServer) NewConsumer(topic string, groupID string) substrate.AsyncMessageSource {
 	source, err := NewAsyncMessageSource(AsyncMessageSourceConfig{
-		url:       "http://localhost:4222",
-		clusterID: ks.clusterID,
+		URL:       "http://localhost:4222",
+		ClusterID: ks.clusterID,
 
-		consumerGroup: groupID,
-		subject:       topic,
+		ConsumerGroup: groupID,
+		Subject:       topic,
 	})
 	if err != nil {
 		panic(err)
@@ -158,11 +158,11 @@ loop3:
 
 func (ks *testServer) canConsume(topic string, groupID string) error {
 	source, err := NewAsyncMessageSource(AsyncMessageSourceConfig{
-		url:       "http://localhost:4222",
-		clusterID: ks.clusterID,
+		URL:       "http://localhost:4222",
+		ClusterID: ks.clusterID,
 
-		consumerGroup: groupID,
-		subject:       topic,
+		ConsumerGroup: groupID,
+		Subject:       topic,
 	})
 	if err != nil {
 		return err

--- a/natsstreaming/nats_streaming.go
+++ b/natsstreaming/nats_streaming.go
@@ -107,10 +107,10 @@ func (p *AsyncMessageSink) Status() (*substrate.Status, error) {
 // AsyncMessageSource represents a nats-streaming message source and implements
 // the substrate.AsyncMessageSource interface.
 type AsyncMessageSourceConfig struct {
-	url           string
-	clusterID     string
-	subject       string
-	consumerGroup string
+	URL           string
+	ClusterID     string
+	Subject       string
+	ConsumerGroup string
 }
 
 type AsyncMessageSource struct {
@@ -119,7 +119,7 @@ type AsyncMessageSource struct {
 }
 
 func NewAsyncMessageSource(c AsyncMessageSourceConfig) (substrate.AsyncMessageSource, error) {
-	conn, err := stan.Connect(c.clusterID, c.consumerGroup+generateID(), stan.NatsURL(c.url))
+	conn, err := stan.Connect(c.ClusterID, c.ConsumerGroup+generateID(), stan.NatsURL(c.URL))
 	if err != nil {
 		return nil, err
 	}
@@ -151,11 +151,11 @@ func (c *AsyncMessageSource) ConsumeMessages(ctx context.Context, messages chan<
 	}
 
 	sub, err := c.conn.QueueSubscribe(
-		c.conf.subject,
-		c.conf.consumerGroup,
+		c.conf.Subject,
+		c.conf.ConsumerGroup,
 		f,
 		stan.StartAt(pb.StartPosition_First),
-		stan.DurableName(c.conf.consumerGroup),
+		stan.DurableName(c.conf.ConsumerGroup),
 		stan.SetManualAckMode(),
 		stan.AckWait(60*time.Second),
 		stan.MaxInflight(32),


### PR DESCRIPTION
Export values so that users can actually configure things. (Can you tell
this was only ever used in tests so far!?)