### PR TITLE
Fix to ack handling

### DIFF
--- a/natsstreaming/nats_streaming.go
+++ b/natsstreaming/nats_streaming.go
@@ -142,11 +142,11 @@ func (c *AsyncMessageSource) ConsumeMessages(ctx context.Context, messages chan<
 
 	f := func(msg *stan.Msg) {
 		cm := &consumerMessage{msg}
+		msgsToAck <- cm
 		select {
 		case <-ctx.Done():
 			return
 		case messages <- cm:
-			msgsToAck <- cm
 		}
 	}
 
@@ -205,6 +205,7 @@ func handleAcks(ctx context.Context, msgsToAck chan *consumerMessage, acks <-cha
 			if err := msgToAck.m.Ack(); err != nil {
 				return fmt.Errorf("failed to ack message with NATS: %v", err.Error())
 			}
+			toAck = toAck[1:]
 		case <-ctx.Done():
 			//return ctx.Err()
 			return nil


### PR DESCRIPTION
This fixes two issues with ack handling.

Acks were not being cleared from the queue after acking, and there was a race condition where acks could be sent by the consumer before we have added them to the list of things to ack.