### PR TITLE
URL based connection

### DIFF
--- a/kafka/doc.go
+++ b/kafka/doc.go
@@ -1,0 +1,23 @@
+// Package kafka provides kafka support for substrate
+//
+// Usage
+//
+// This package support two methods of use.  The first is to directly use this package. See the function documentation for more details.
+//
+// The second method is to use the suburl package. See https://godoc.org/github.com/uw-labs/substrate/suburl for more information.
+//
+// Using suburl
+//
+// The url structure is kafka://host:port/topic/
+//
+// The following url parameters are available:
+//
+//      broker - Specifies additional broker addresses in the form host%3Aport (where %3A is a url encoded ':')
+//
+// Additionally, for sources, the following url parameters are available
+//
+//      offset           - The initial offset. Valid values are `newest` and `oldest`.
+//      consumer-group   - The consumer group id
+//      metadata-refresh - How frequently to refresh the cluster metadata. E.g., '10s' '2m'
+//
+package kafka

--- a/kafka/kafka_url.go
+++ b/kafka/kafka_url.go
@@ -1,0 +1,78 @@
+package kafka
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/uw-labs/substrate"
+	"github.com/uw-labs/substrate/suburl"
+)
+
+func init() {
+	suburl.RegisterSink("kafka", newKafkaSink)
+	suburl.RegisterSource("kafka", newKafkaSource)
+}
+
+func newKafkaSink(u *url.URL) (substrate.AsyncMessageSink, error) {
+	q := u.Query()
+
+	topic := strings.Trim(u.Path, "/")
+
+	if strings.Contains(topic, "/") {
+		return nil, fmt.Errorf("error parsing topic from url (%s)", topic)
+	}
+
+	conf := AsyncMessageSinkConfig{
+		Brokers: []string{u.Host},
+		Topic:   topic,
+	}
+
+	conf.Brokers = append(conf.Brokers, q["broker"]...)
+
+	return kafkaSinker(conf)
+}
+
+var kafkaSinker = NewAsyncMessageSink
+
+func newKafkaSource(u *url.URL) (substrate.AsyncMessageSource, error) {
+	q := u.Query()
+
+	topic := strings.Trim(u.Path, "/")
+
+	if strings.Contains(topic, "/") {
+		return nil, fmt.Errorf("error parsing topic from url (%s)", topic)
+	}
+
+	conf := AsyncMessageSourceConfig{
+		Brokers:       []string{u.Host},
+		ConsumerGroup: q.Get("consumer-group"),
+		Topic:         topic,
+	}
+
+	conf.Brokers = append(conf.Brokers, q["broker"]...)
+
+	switch q.Get("offset") {
+	case "newest":
+		conf.Offset = OffsetNewest
+	case "oldest":
+		conf.Offset = OffsetOldest
+	case "":
+	default:
+		return nil, fmt.Errorf("ignoring unknown offset value '%s'", q.Get("offset"))
+	}
+
+	dur := q.Get("metadata-refresh")
+	if dur != "" {
+		d, err := time.ParseDuration(dur)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse refresh duration : %v", err)
+		}
+		conf.MetadataRefreshFrequency = d
+	}
+
+	return kafkaSourcer(conf)
+}
+
+var kafkaSourcer = NewAsyncMessageSource

--- a/kafka/kafka_url_test.go
+++ b/kafka/kafka_url_test.go
@@ -1,0 +1,146 @@
+package kafka
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Shopify/sarama"
+	"github.com/stretchr/testify/assert"
+	"github.com/uw-labs/substrate"
+	"github.com/uw-labs/substrate/suburl"
+)
+
+func TestKafkaSink(t *testing.T) {
+	assert := assert.New(t)
+
+	tests := []struct {
+		name        string
+		input       string
+		expected    AsyncMessageSinkConfig
+		expectedErr error
+	}{
+		{
+			name:  "simple",
+			input: "kafka://localhost",
+			expected: AsyncMessageSinkConfig{
+				Brokers: []string{"localhost"},
+			},
+			expectedErr: nil,
+		},
+		{
+			name:  "standard",
+			input: "kafka://localhost:123/t1",
+			expected: AsyncMessageSinkConfig{
+				Brokers: []string{"localhost:123"},
+				Topic:   "t1",
+			},
+			expectedErr: nil,
+		},
+		{
+			name:  "with-port",
+			input: "kafka://localhost:123/t1",
+			expected: AsyncMessageSinkConfig{
+				Brokers: []string{"localhost:123"},
+				Topic:   "t1",
+			},
+			expectedErr: nil,
+		},
+		{
+			name:  "everything",
+			input: "kafka://localhost:123/t1/?broker=localhost:234&broker=localhost:345",
+			expected: AsyncMessageSinkConfig{
+				Brokers: []string{"localhost:123", "localhost:234", "localhost:345"},
+				Topic:   "t1",
+			},
+			expectedErr: nil,
+		},
+	}
+
+	for _, tst := range tests {
+		t.Run(tst.name, func(t *testing.T) {
+
+			var conf AsyncMessageSinkConfig
+			kafkaSinker = func(c AsyncMessageSinkConfig) (substrate.AsyncMessageSink, error) {
+				conf = c
+				return nil, nil
+			}
+			_, err := suburl.NewSink(tst.input)
+
+			if tst.expectedErr != err {
+				t.Errorf("expected error %v but got %v", tst.expectedErr, err)
+			}
+
+			assert.Equal(tst.expected, conf)
+		})
+	}
+
+}
+
+func TestKafkaSource(t *testing.T) {
+	assert := assert.New(t)
+
+	tests := []struct {
+		name        string
+		input       string
+		expected    AsyncMessageSourceConfig
+		expectedErr error
+	}{
+		{
+			name:  "simple",
+			input: "kafka://localhost",
+			expected: AsyncMessageSourceConfig{
+				Brokers: []string{"localhost"},
+			},
+			expectedErr: nil,
+		},
+		{
+			name:  "standard",
+			input: "kafka://localhost:123/t1",
+			expected: AsyncMessageSourceConfig{
+				Brokers: []string{"localhost:123"},
+				Topic:   "t1",
+			},
+			expectedErr: nil,
+		},
+		{
+			name:  "with-port",
+			input: "kafka://localhost:123/t1",
+			expected: AsyncMessageSourceConfig{
+				Brokers: []string{"localhost:123"},
+				Topic:   "t1",
+			},
+			expectedErr: nil,
+		},
+		{
+			name:  "everything",
+			input: "kafka://localhost:123/t1/?offset=latest&consumer-group=g1&metadata-refresh=2s&broker=localhost:234&broker=localhost:345",
+			expected: AsyncMessageSourceConfig{
+				Brokers:                  []string{"localhost:123", "localhost:234", "localhost:345"},
+				ConsumerGroup:            "g1",
+				MetadataRefreshFrequency: 2 * time.Second,
+				Offset:                   sarama.OffsetNewest,
+				Topic:                    "t1",
+			},
+			expectedErr: nil,
+		},
+	}
+
+	for _, tst := range tests {
+		t.Run(tst.name, func(t *testing.T) {
+
+			var conf AsyncMessageSourceConfig
+			kafkaSourcer = func(c AsyncMessageSourceConfig) (substrate.AsyncMessageSource, error) {
+				conf = c
+				return nil, nil
+			}
+			_, err := suburl.NewSource(tst.input)
+
+			if tst.expectedErr != err {
+				t.Errorf("expected error %v but got %v", tst.expectedErr, err)
+			}
+
+			assert.Equal(tst.expected, conf)
+		})
+	}
+
+}

--- a/natsstreaming/doc.go
+++ b/natsstreaming/doc.go
@@ -1,0 +1,24 @@
+// Package natsstreaming provides kafka support for substrate
+//
+// Usage
+//
+// This package support two methods of use.  The first is to directly use this package. See the function documentation for more details.
+//
+// The second method is to use the suburl package. See https://godoc.org/github.com/uw-labs/substrate/suburl for more information.
+//
+// Using suburl
+//
+// The url structure is nats-streaming://host:port/subject/
+//
+// The following url parameters are available:
+//
+//      cluster-id  - The nats streaming cluster id
+//      client-id   - The nats streaming client id
+//
+// Additionally, for sources, the following url parameters are available
+//
+//      queue-group      - The nats streaming queue group
+//      max-in-flight    - The nats streaming MaxInFlight value
+//      ack-wait         - The nats streaming AckWait duration, e.g., '30s', '2m'
+//
+package natsstreaming

--- a/natsstreaming/nats_streaming_url.go
+++ b/natsstreaming/nats_streaming_url.go
@@ -1,0 +1,78 @@
+package natsstreaming
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/uw-labs/substrate"
+	"github.com/uw-labs/substrate/suburl"
+)
+
+func init() {
+	suburl.RegisterSink("nats-streaming", newNatsStreamingSink)
+	suburl.RegisterSource("nats-streaming", newNatsStreamingSource)
+}
+
+func newNatsStreamingSink(u *url.URL) (substrate.AsyncMessageSink, error) {
+	q := u.Query()
+
+	natsURL := "nats://" + u.Host
+
+	subject := strings.Trim(u.Path, "/")
+	if strings.Contains(subject, "/") {
+		return nil, fmt.Errorf("error parsing subject from url (%s)", subject)
+	}
+
+	return natsStreamingSinker(AsyncMessageSinkConfig{
+		URL:       natsURL,
+		ClusterID: q.Get("cluster-id"),
+		ClientID:  q.Get("client-id"),
+		Subject:   subject,
+	})
+}
+
+var natsStreamingSinker = NewAsyncMessageSink
+
+func newNatsStreamingSource(u *url.URL) (substrate.AsyncMessageSource, error) {
+	q := u.Query()
+
+	natsURL := "nats://" + u.Host
+
+	subject := strings.Trim(u.Path, "/")
+	if strings.Contains(subject, "/") {
+		return nil, fmt.Errorf("error parsing topic from url (%s)", subject)
+	}
+
+	conf := AsyncMessageSourceConfig{
+		URL:        natsURL,
+		ClusterID:  q.Get("cluster-id"),
+		QueueGroup: q.Get("queue-group"),
+		ClientID:   q.Get("client-id"),
+		Subject:    subject,
+	}
+
+	maxInflightString := q.Get("max-in-flight")
+	if maxInflightString != "" {
+		maxInflight, err := strconv.Atoi(maxInflightString)
+		if err != nil {
+			return nil, err
+		}
+		conf.MaxInFlight = maxInflight
+	}
+
+	ackWaitString := q.Get("ack-wait")
+	if ackWaitString != "" {
+		ackWait, err := time.ParseDuration(ackWaitString)
+		if err != nil {
+			return nil, err
+		}
+		conf.AckWait = ackWait
+	}
+
+	return natsStreamingSourcer(conf)
+}
+
+var natsStreamingSourcer = NewAsyncMessageSource

--- a/natsstreaming/nats_streaming_url_test.go
+++ b/natsstreaming/nats_streaming_url_test.go
@@ -1,0 +1,161 @@
+package natsstreaming
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/uw-labs/substrate"
+	"github.com/uw-labs/substrate/suburl"
+)
+
+func TestNatsStreamingURLSink(t *testing.T) {
+	assert := assert.New(t)
+
+	tests := []struct {
+		name        string
+		input       string
+		expected    AsyncMessageSinkConfig
+		expectedErr bool
+	}{
+		{
+			name:  "simple",
+			input: "nats-streaming://localhost/t1",
+			expected: AsyncMessageSinkConfig{
+				URL:     "nats://localhost",
+				Subject: "t1",
+			},
+			expectedErr: false,
+		},
+		{
+			name:  "simple-trailing-slash",
+			input: "nats-streaming://localhost/t1/",
+			expected: AsyncMessageSinkConfig{
+				URL:     "nats://localhost",
+				Subject: "t1",
+			},
+			expectedErr: false,
+		},
+		{
+			name:  "with-port",
+			input: "nats-streaming://localhost:123/t1",
+			expected: AsyncMessageSinkConfig{
+				URL:     "nats://localhost:123",
+				Subject: "t1",
+			},
+			expectedErr: false,
+		},
+		{
+			name:  "everything",
+			input: "nats-streaming://localhost:123/t1?cluster-id=cid-1&client-id=client-1",
+			expected: AsyncMessageSinkConfig{
+				URL:       "nats://localhost:123",
+				ClusterID: "cid-1",
+				ClientID:  "client-1",
+				Subject:   "t1",
+			},
+			expectedErr: false,
+		},
+		{
+			name:        "extra-path-elements",
+			input:       "nats-streaming://localhost:123/aa/bb",
+			expected:    AsyncMessageSinkConfig{},
+			expectedErr: true,
+		},
+	}
+
+	for _, tst := range tests {
+		t.Run(tst.name, func(t *testing.T) {
+			var c AsyncMessageSinkConfig
+			natsStreamingSinker = func(conf AsyncMessageSinkConfig) (substrate.AsyncMessageSink, error) {
+				c = conf
+				return nil, nil
+			}
+			_, err := suburl.NewSink(tst.input)
+
+			if tst.expectedErr == (err == nil) {
+				t.Errorf("expected error %v but got %v", tst.expectedErr, err)
+			}
+
+			assert.Equal(tst.expected, c)
+		})
+	}
+
+}
+
+func TestNatsStreamingURLSource(t *testing.T) {
+	assert := assert.New(t)
+
+	tests := []struct {
+		name        string
+		input       string
+		expected    AsyncMessageSourceConfig
+		expectedErr bool
+	}{
+		{
+			name:  "simple",
+			input: "nats-streaming://localhost/t1",
+			expected: AsyncMessageSourceConfig{
+				URL:     "nats://localhost",
+				Subject: "t1",
+			},
+			expectedErr: false,
+		},
+		{
+			name:  "simple-trailing-slash",
+			input: "nats-streaming://localhost/t1/",
+			expected: AsyncMessageSourceConfig{
+				URL:     "nats://localhost",
+				Subject: "t1",
+			},
+			expectedErr: false,
+		},
+		{
+			name:  "with-port",
+			input: "nats-streaming://localhost:123/t1",
+			expected: AsyncMessageSourceConfig{
+				URL:     "nats://localhost:123",
+				Subject: "t1",
+			},
+			expectedErr: false,
+		},
+		{
+			name:  "everything",
+			input: "nats-streaming://localhost:123/t1?cluster-id=cid1&client-id=clie1&queue-group=qg1&ack-wait=30s&max-in-flight=1234",
+			expected: AsyncMessageSourceConfig{
+				URL:         "nats://localhost:123",
+				ClusterID:   "cid1",
+				QueueGroup:  "qg1",
+				ClientID:    "clie1",
+				Subject:     "t1",
+				AckWait:     30 * time.Second,
+				MaxInFlight: 1234,
+			},
+			expectedErr: false,
+		},
+		{
+			name:        "extra-path-elements",
+			input:       "nats-streaming://localhost:123/aa/bb",
+			expected:    AsyncMessageSourceConfig{},
+			expectedErr: true,
+		},
+	}
+
+	for _, tst := range tests {
+		t.Run(tst.name, func(t *testing.T) {
+			var c AsyncMessageSourceConfig
+			natsStreamingSourcer = func(conf AsyncMessageSourceConfig) (substrate.AsyncMessageSource, error) {
+				c = conf
+				return nil, nil
+			}
+			_, err := suburl.NewSource(tst.input)
+
+			if tst.expectedErr == (err == nil) {
+				t.Errorf("expected error %v but got %v", tst.expectedErr, err)
+			}
+
+			assert.Equal(tst.expected, c)
+		})
+	}
+
+}

--- a/suburl/doc.go
+++ b/suburl/doc.go
@@ -1,0 +1,34 @@
+// Package suburl provides a generic URL based interface for obtaining substrate
+// source and sink objects.
+//
+// Usage
+//
+// An example of obtaining a nats streaming source is shown below.
+//
+//      source, err := suburl.NewSource("nats-streaming://localhost:4222/my-subject?cluster-id=foo&consumer-id=bar")
+//      if err != nil {
+//              // error handling
+//      }
+//      defer source.Close()
+//
+//      // use source here
+//
+// Here is an example of obtaining a kafka sink.
+//
+//      sink, err := suburl.NewSink("kafka://localhost:9092/my-topic/?broker=localhost%3A9092&broker=localhost%3A9092")
+//      if err != nil {
+//              // error handling
+//      }
+//      defer sink.Close()
+//
+//      // use sink here
+//
+// To use a particular url scheme, the driver has to be registered, for example:
+//
+//      import _ "github.com/uw-labs/substrate/kafka"
+//
+// More complete documentation of options
+//
+// For a full description of the url options available for each scheme, see the documentation for the particular driver,
+// for example https://godoc.org/github.com/uw-labs/substrate/kafka or https://godoc.org/github.com/uw-labs/substrate/natsstreaming.
+package suburl

--- a/suburl/sink.go
+++ b/suburl/sink.go
@@ -1,0 +1,45 @@
+package suburl
+
+import (
+	"fmt"
+	"github.com/uw-labs/substrate"
+	"net/url"
+	"sync"
+)
+
+var (
+	sinkTypesMu sync.RWMutex
+	sinkTypes   = make(map[string]func(url *url.URL) (substrate.AsyncMessageSink, error))
+)
+
+func RegisterSink(scheme string, sinkFunc func(url *url.URL) (substrate.AsyncMessageSink, error)) {
+	sinkTypesMu.Lock()
+	defer sinkTypesMu.Unlock()
+	if sinkFunc == nil {
+		panic("pubsub: sink function is nil")
+	}
+	if _, dup := sinkTypes[scheme]; dup {
+		panic("pubsub: RegisterSink called more than once for sink " + scheme)
+	}
+	sinkTypes[scheme] = sinkFunc
+}
+
+// NewSink will return a message sink based on the supplied URL.
+// Examples:
+//  kafka://localhost:123/my-topic/?metadata-refresh=2s&broker=localhost:234&broker=localhost:345
+//  nats-streaming://localhost:123/my-subject?cluster-id=cid-1&consumer-id=cons-1
+func NewSink(u string) (substrate.AsyncMessageSink, error) {
+	parsed, err := url.Parse(u)
+	if err != nil {
+		return nil, err
+	}
+
+	sinkTypesMu.RLock()
+	defer sinkTypesMu.RUnlock()
+
+	f := sinkTypes[parsed.Scheme]
+	if f == nil {
+		return nil, fmt.Errorf("unknown scheme : %s", parsed.Scheme)
+	}
+	return f(parsed)
+}

--- a/suburl/source.go
+++ b/suburl/source.go
@@ -1,0 +1,43 @@
+package suburl
+
+import (
+	"fmt"
+	"github.com/uw-labs/substrate"
+	"net/url"
+	"sync"
+)
+
+var (
+	sourceTypesMu sync.RWMutex
+	sourceTypes   = make(map[string]func(url *url.URL) (substrate.AsyncMessageSource, error))
+)
+
+func RegisterSource(scheme string, sinkFunc func(url *url.URL) (substrate.AsyncMessageSource, error)) {
+	sourceTypesMu.Lock()
+	defer sourceTypesMu.Unlock()
+	if sinkFunc == nil {
+		panic("pubsub: sink function is nil")
+	}
+	if _, dup := sourceTypes[scheme]; dup {
+		panic("pubsub: RegisterSink called more than once for sink " + scheme)
+	}
+	sourceTypes[scheme] = sinkFunc
+}
+
+// NewSource returns a message source based on the supplied URL.
+func NewSource(u string) (substrate.AsyncMessageSource, error) {
+	parsed, err := url.Parse(u)
+	if err != nil {
+		return nil, err
+	}
+
+	sourceTypesMu.RLock()
+	defer sourceTypesMu.RUnlock()
+
+	f := sourceTypes[parsed.Scheme]
+	if f == nil {
+		return nil, fmt.Errorf("unknown scheme : %s", parsed.Scheme)
+	}
+
+	return f(parsed)
+}


### PR DESCRIPTION
This implements a URL based connection approach, enabling switching
between different types of broken by configuration alone.  The various
drivers register themselves in much the same way as sql drivers used
with the standard library.

Some examples are below, see included documentation for more details.

```
source, err := suburl.NewSource("nats-streaming://localhost:4222/my-subject?cluster-id=foo&consumer-id=bar")
if err != nil {
        // error handling
}
defer source.Close()

// use source here
```

```
Here is an example of obtaining a kafka sink.

sink, err := suburl.NewSink("kafka://localhost:9092/my-topic/?broker=localhost%3A9092&broker=localhost%3A9092")
if err != nil {
        // error handling
}
defer sink.Close()

// use sink here

```