### PR TITLE
Add TestEnd method to TestServer

### DIFF
--- a/internal/testshared/testshared.go
+++ b/internal/testshared/testshared.go
@@ -20,6 +20,7 @@ import (
 type TestServer interface {
 	NewConsumer(topic string, groupID string) substrate.AsyncMessageSource
 	NewProducer(topic string) substrate.AsyncMessageSink
+	TestEnd()
 }
 
 // TestAll is the main entrypoint from the backend implmenentation tests to
@@ -45,6 +46,7 @@ func TestAll(t *testing.T, ts TestServer) {
 			x(t, ts)
 		}
 		t.Run(runtime.FuncForPC(reflect.ValueOf(x).Pointer()).Name(), f)
+		ts.TestEnd()
 	}
 }
 

--- a/kafka/integration_test.go
+++ b/kafka/integration_test.go
@@ -60,6 +60,8 @@ func (ks *testServer) NewProducer(topic string) substrate.AsyncMessageSink {
 	return s
 }
 
+func (ks *testServer) TestEnd() {}
+
 func (ks *testServer) Kill() error {
 	cmd := exec.Command("docker", "rm", "-f", ks.containerName)
 

--- a/natsstreaming/integration_test.go
+++ b/natsstreaming/integration_test.go
@@ -63,6 +63,8 @@ func (ks *testServer) NewProducer(topic string) substrate.AsyncMessageSink {
 	return sink
 }
 
+func (ks *testServer) TestEnd() {}
+
 func (ks *testServer) Kill() error {
 	cmd := exec.Command("docker", "rm", "-f", ks.containerName)
 


### PR DESCRIPTION
This adds a new TestEnd method to the TestServer interface to allow each
test server a way to do cleanup etc after each test has run.  This is
not used anywhere (beyond empty implementation) just yet.