### PR TITLE
Add initial proximo support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,5 @@ Current implementations and their status
 | ---------------------------------------- | ------------- |
 | Apache Kafka                             | beta          |
 | Nats streaming                           | beta          |
+| Proximo                                  | alpha         |
 

--- a/proximo/doc.go
+++ b/proximo/doc.go
@@ -1,0 +1,18 @@
+// Package proximo provides proximo support for substrate
+//
+// Usage
+//
+// This package support two methods of use.  The first is to directly use this package. See the function documentation for more details.
+//
+// The second method is to use the suburl package. See https://godoc.org/github.com/uw-labs/substrate/suburl for more information.
+//
+// Using suburl
+//
+// The url structure is proximo://host:port/topic/
+//
+// Additionally, for sources, the following url parameters are available
+//
+//      offset           - The initial offset. Valid values are `newest` and `oldest`.
+//      consumer-group   - The consumer group id
+//
+package proximo

--- a/proximo/integration_test.go
+++ b/proximo/integration_test.go
@@ -1,0 +1,87 @@
+package proximo
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"os/exec"
+	"testing"
+
+	"github.com/uw-labs/substrate"
+	"github.com/uw-labs/substrate/internal/testshared"
+)
+
+func TestAll(t *testing.T) {
+
+	k, err := runServer()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer k.Kill()
+
+	testshared.TestAll(t, k)
+}
+
+type testServer struct {
+	cmd  *exec.Cmd
+	port int
+}
+
+func (ks *testServer) NewConsumer(topic string, groupID string) substrate.AsyncMessageSource {
+	s, err := NewAsyncMessageSource(AsyncMessageSourceConfig{
+		Broker:        fmt.Sprintf("localhost:%d", ks.port),
+		ConsumerGroup: groupID,
+		Topic:         topic,
+		//	Offset:        OffsetOldest,
+		Insecure: true,
+	})
+
+	if err != nil {
+		panic(err)
+	}
+	return s
+}
+
+func (ks *testServer) NewProducer(topic string) substrate.AsyncMessageSink {
+	s, err := NewAsyncMessageSink(AsyncMessageSinkConfig{
+		Broker: fmt.Sprintf("localhost:%d", ks.port),
+		Topic:  topic,
+	})
+	if err != nil {
+		panic(err)
+	}
+	return s
+}
+
+func (ks *testServer) TestEnd() {}
+
+func (ks *testServer) Kill() error {
+	return ks.cmd.Process.Kill()
+}
+
+func runServer() (*testServer, error) {
+
+	cmd := exec.CommandContext(
+		context.Background(),
+		"proximo-server",
+		"mem",
+	)
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+
+	ks := &testServer{cmd, 6868}
+
+	return ks, nil
+}
+
+func generateID() string {
+	random := []byte{0, 0, 0, 0, 0, 0, 0, 0}
+	_, err := rand.Read(random)
+	if err != nil {
+		panic(err)
+	}
+	return hex.EncodeToString(random)
+}

--- a/proximo/proximo_sink.go
+++ b/proximo/proximo_sink.go
@@ -1,0 +1,71 @@
+package proximo
+
+import (
+	"context"
+
+	proximoc "github.com/uw-labs/proximo/proximoc-go"
+	"github.com/uw-labs/substrate"
+)
+
+var (
+	_ substrate.AsyncMessageSink = (*asyncMessageSink)(nil)
+)
+
+type AsyncMessageSinkConfig struct {
+	Broker   string
+	Topic    string
+	Insecure bool
+}
+
+func NewAsyncMessageSink(config AsyncMessageSinkConfig) (substrate.AsyncMessageSink, error) {
+
+	client, err := proximoc.DialProducer(
+		context.Background(),
+		config.Broker,
+		config.Topic,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	sink := asyncMessageSink{
+		client: client,
+		Topic:  config.Topic,
+	}
+	return &sink, nil
+}
+
+type asyncMessageSink struct {
+	client *proximoc.ProducerConn
+	Topic  string
+}
+
+func (ams *asyncMessageSink) PublishMessages(ctx context.Context, acks chan<- substrate.Message, messages <-chan substrate.Message) (rerr error) {
+
+	for {
+
+		select {
+		case m := <-messages:
+			if err := ams.client.Produce(m.Data()); err != nil {
+				return err
+			}
+			select {
+			case acks <- m:
+			case <-ctx.Done():
+				return nil
+			}
+		case <-ctx.Done():
+			return nil
+		}
+	}
+}
+
+func (ams *asyncMessageSink) Status() (*substrate.Status, error) {
+	return &substrate.Status{Working: true}, nil
+}
+
+// Close implements the Close method of the substrate.AsyncMessageSink
+// interface.
+func (ams *asyncMessageSink) Close() error {
+	return ams.client.Close()
+}

--- a/proximo/proximo_source.go
+++ b/proximo/proximo_source.go
@@ -1,0 +1,163 @@
+package proximo
+
+import (
+	"context"
+	"io"
+
+	"github.com/pkg/errors"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+
+	proximoc "github.com/uw-labs/proximo/proximoc-go"
+	"github.com/uw-labs/substrate"
+)
+
+const (
+	// OffsetOldest indicates the oldest appropriate message available on the broker.
+	OffsetOldest int64 = 1
+	// OffsetNewest indicates the next appropriate message available on the broker.
+	OffsetNewest int64 = 2
+)
+
+var (
+	_ substrate.AsyncMessageSource = (*asyncMessageSource)(nil)
+)
+
+// AsyncMessageSource represents a proximo message source and implements the
+// substrate.AsyncMessageSource interface.
+type AsyncMessageSourceConfig struct {
+	ConsumerGroup string
+	Topic         string
+	Broker        string
+	//	Offset        int64 TODO: offset for proximo
+	Insecure bool
+}
+
+func NewAsyncMessageSource(c AsyncMessageSourceConfig) (substrate.AsyncMessageSource, error) {
+
+	return &asyncMessageSource{
+		broker:        c.Broker,
+		consumerGroup: c.ConsumerGroup,
+		topic:         c.Topic,
+		insecure:      c.Insecure,
+	}, nil
+}
+
+type asyncMessageSource struct {
+	broker        string
+	consumerGroup string
+	topic         string
+	insecure      bool
+}
+
+type consMsg struct {
+	pm *proximoc.Message
+}
+
+func (cm consMsg) Data() []byte {
+	return cm.pm.Data
+}
+
+func (ams *asyncMessageSource) ConsumeMessages(ctx context.Context, messages chan<- substrate.Message, acks <-chan substrate.Message) error {
+
+	eg, ctx := errgroup.WithContext(ctx)
+
+	var opts []grpc.DialOption
+	if ams.insecure {
+		opts = append(opts, grpc.WithInsecure())
+	}
+
+	conn, err := grpc.DialContext(ctx, ams.broker, opts...)
+	if err != nil {
+		return errors.Wrapf(err, "fail to dial %s", ams.broker)
+	}
+	defer conn.Close()
+
+	client := proximoc.NewMessageSourceClient(conn)
+
+	stream, err := client.Consume(ctx)
+	if err != nil {
+		return errors.Wrap(err, "fail to consume")
+	}
+
+	defer stream.CloseSend()
+
+	if err := stream.Send(&proximoc.ConsumerRequest{
+		StartRequest: &proximoc.StartConsumeRequest{
+			Topic:    ams.topic,
+			Consumer: ams.consumerGroup,
+		},
+	}); err != nil {
+		return err
+	}
+
+	toAck := make(chan substrate.Message)
+
+	eg.Go(func() error {
+		var toAckList []substrate.Message
+		for {
+			select {
+			case ta := <-toAck:
+				toAckList = append(toAckList, ta)
+			case a := <-acks:
+				switch {
+				case len(toAckList) == 0:
+					return substrate.InvalidAckError{Acked: a}
+				case a != toAckList[0]:
+					return substrate.InvalidAckError{Acked: a, Expected: toAckList[0]}
+				default:
+					id := toAckList[0].(consMsg).pm.Id
+					if err := stream.Send(&proximoc.ConsumerRequest{Confirmation: &proximoc.Confirmation{MsgID: id}}); err != nil {
+						if err == io.EOF || grpc.Code(err) == codes.Canceled {
+							return nil
+						}
+						return err
+					}
+					toAckList = toAckList[1:]
+				}
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+	})
+
+	eg.Go(func() error {
+		for {
+			in, err := stream.Recv()
+			if err != nil {
+				if err != io.EOF && grpc.Code(err) != codes.Canceled {
+					return err
+				}
+				return nil
+			}
+
+			m := consMsg{in}
+			select {
+			case toAck <- m:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+			select {
+			case messages <- consMsg{in}:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+	})
+
+	err = eg.Wait()
+	if err == context.Canceled {
+		return nil
+	}
+	return err
+
+}
+
+func (ams *asyncMessageSource) Status() (*substrate.Status, error) {
+	return &substrate.Status{Working: true}, nil
+}
+
+func (ams *asyncMessageSource) Close() error {
+	return nil
+}

--- a/proximo/proximo_source.go
+++ b/proximo/proximo_source.go
@@ -67,6 +67,7 @@ func (ams *asyncMessageSource) ConsumeMessages(ctx context.Context, messages cha
 	if ams.insecure {
 		opts = append(opts, grpc.WithInsecure())
 	}
+	opts = append(opts, grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(1024*1024*16)))
 
 	conn, err := grpc.DialContext(ctx, ams.broker, opts...)
 	if err != nil {

--- a/proximo/proximo_source.go
+++ b/proximo/proximo_source.go
@@ -67,7 +67,7 @@ func (ams *asyncMessageSource) ConsumeMessages(ctx context.Context, messages cha
 	if ams.insecure {
 		opts = append(opts, grpc.WithInsecure())
 	}
-	opts = append(opts, grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(1024*1024*16)))
+	opts = append(opts, grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(1024*1024*64)))
 
 	conn, err := grpc.DialContext(ctx, ams.broker, opts...)
 	if err != nil {

--- a/proximo/proximo_url.go
+++ b/proximo/proximo_url.go
@@ -1,0 +1,84 @@
+package proximo
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/uw-labs/substrate"
+	"github.com/uw-labs/substrate/suburl"
+)
+
+func init() {
+	suburl.RegisterSink("proximo", newProximoSink)
+	suburl.RegisterSource("proximo", newProximoSource)
+}
+
+func newProximoSink(u *url.URL) (substrate.AsyncMessageSink, error) {
+	q := u.Query()
+
+	topic := strings.Trim(u.Path, "/")
+
+	if strings.Contains(topic, "/") {
+		return nil, fmt.Errorf("error parsing topic from url (%s)", topic)
+	}
+
+	conf := AsyncMessageSinkConfig{
+		Broker: u.Host,
+		Topic:  topic,
+	}
+
+	switch q.Get("insecure") {
+	case "true":
+		conf.Insecure = true
+	case "false":
+		conf.Insecure = false
+	default:
+		conf.Insecure = false
+	}
+
+	return proximoSinker(conf)
+}
+
+var proximoSinker = NewAsyncMessageSink
+
+func newProximoSource(u *url.URL) (substrate.AsyncMessageSource, error) {
+	q := u.Query()
+
+	topic := strings.Trim(u.Path, "/")
+
+	if strings.Contains(topic, "/") {
+		return nil, fmt.Errorf("error parsing topic from url (%s)", topic)
+	}
+
+	conf := AsyncMessageSourceConfig{
+		Broker:        u.Host,
+		ConsumerGroup: q.Get("consumer-group"),
+		Topic:         topic,
+	}
+
+	switch q.Get("insecure") {
+	case "true":
+		conf.Insecure = true
+	case "false":
+		conf.Insecure = false
+	default:
+		conf.Insecure = false
+	}
+
+	/*
+		switch q.Get("offset") {
+		case "newest":
+			conf.Offset = OffsetNewest
+		case "oldest":
+			conf.Offset = OffsetOldest
+		case "":
+		default:
+			return nil, fmt.Errorf("ignoring unknown offset value '%s'", q.Get("offset"))
+		}
+	*/
+
+	return proximoSourcer(conf)
+}
+
+var proximoSourcer = NewAsyncMessageSource

--- a/proximo/proximo_url_test.go
+++ b/proximo/proximo_url_test.go
@@ -1,0 +1,137 @@
+package proximo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/uw-labs/substrate"
+	"github.com/uw-labs/substrate/suburl"
+)
+
+func TestProximoSink(t *testing.T) {
+	assert := assert.New(t)
+
+	tests := []struct {
+		name        string
+		input       string
+		expected    AsyncMessageSinkConfig
+		expectedErr error
+	}{
+		{
+			name:  "simple",
+			input: "proximo://localhost/topic",
+			expected: AsyncMessageSinkConfig{
+				Broker: "localhost",
+				Topic:  "topic",
+			},
+			expectedErr: nil,
+		},
+		{
+			name:  "with-port",
+			input: "proximo://localhost:123/t1",
+			expected: AsyncMessageSinkConfig{
+				Broker: "localhost:123",
+				Topic:  "t1",
+			},
+			expectedErr: nil,
+		},
+		{
+			name:  "insecure",
+			input: "proximo://localhost:123/t1?insecure=true",
+			expected: AsyncMessageSinkConfig{
+				Broker:   "localhost:123",
+				Topic:    "t1",
+				Insecure: true,
+			},
+			expectedErr: nil,
+		},
+	}
+
+	for _, tst := range tests {
+		t.Run(tst.name, func(t *testing.T) {
+
+			var conf AsyncMessageSinkConfig
+			proximoSinker = func(c AsyncMessageSinkConfig) (substrate.AsyncMessageSink, error) {
+				conf = c
+				return nil, nil
+			}
+			_, err := suburl.NewSink(tst.input)
+
+			if tst.expectedErr != err {
+				t.Errorf("expected error %v but got %v", tst.expectedErr, err)
+			}
+
+			assert.Equal(tst.expected, conf)
+		})
+	}
+
+}
+
+func TestProximoSource(t *testing.T) {
+	assert := assert.New(t)
+
+	tests := []struct {
+		name        string
+		input       string
+		expected    AsyncMessageSourceConfig
+		expectedErr error
+	}{
+		{
+			name:  "simple",
+			input: "proximo://localhost",
+			expected: AsyncMessageSourceConfig{
+				Broker: "localhost",
+			},
+			expectedErr: nil,
+		},
+		{
+			name:  "with-port",
+			input: "proximo://localhost:123/t1",
+			expected: AsyncMessageSourceConfig{
+				Broker: "localhost:123",
+				Topic:  "t1",
+			},
+			expectedErr: nil,
+		},
+		{
+			name:  "insecure",
+			input: "proximo://localhost:123/t1?insecure=true",
+			expected: AsyncMessageSourceConfig{
+				Broker:   "localhost:123",
+				Topic:    "t1",
+				Insecure: true,
+			},
+			expectedErr: nil,
+		},
+		{
+			name:  "everything",
+			input: "proximo://localhost:123/t1/?offset=newest&consumer-group=g1",
+			expected: AsyncMessageSourceConfig{
+				Broker:        "localhost:123",
+				ConsumerGroup: "g1",
+				//Offset:   foo,
+				Topic: "t1",
+			},
+			expectedErr: nil,
+		},
+	}
+
+	for _, tst := range tests {
+		t.Run(tst.name, func(t *testing.T) {
+
+			var conf AsyncMessageSourceConfig
+			proximoSourcer = func(c AsyncMessageSourceConfig) (substrate.AsyncMessageSource, error) {
+				conf = c
+				return nil, nil
+			}
+			_, err := suburl.NewSource(tst.input)
+
+			if tst.expectedErr != err {
+				t.Errorf("expected error %v but got %v", tst.expectedErr, err)
+			}
+
+			assert.Equal(tst.expected, conf)
+		})
+	}
+
+}


### PR DESCRIPTION
This adds initial support for https://github.com/uw-labs/proximo as a
backend as both a source and a sink.

In order to better fit with substrates goals and design, we don't use
the default proximo client here.  This also leads to significantly
better throughput in my testing.

Also included is use of proximo via the substrate url based addressing.