### PR TITLE
Refactor synchronous message sink

### DIFF
--- a/sync_adapter_sink.go
+++ b/sync_adapter_sink.go
@@ -3,6 +3,16 @@ package substrate
 import (
 	"context"
 	"errors"
+
+	"golang.org/x/sync/errgroup"
+)
+
+var (
+	// ErrSinkAlreadyClosed is an error returned when user tries to publish a message or
+	// close a sink after it was already closed.
+	ErrSinkAlreadyClosed = errors.New("sink was closed already")
+	// ErrSinkClosedDuringSend is an error returned when a sing is closed while sending a message.
+	ErrSinkClosedDuringSend = errors.New("sink was closed while sending the message")
 )
 
 // NewSynchronousMessageSink returns a new synchronous message sink, given an
@@ -34,7 +44,7 @@ type synchronousMessageSinkAdapter struct {
 
 type produceReq struct {
 	m    Message
-	done chan struct{}
+	done chan error
 	ctx  context.Context
 }
 
@@ -43,39 +53,54 @@ func (spa *synchronousMessageSinkAdapter) loop() {
 	toSend := make(chan Message)
 	acks := make(chan Message)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	produceErr := make(chan error)
+	errSinkClosed := errors.New("sink closed")
+	eg, ctx := errgroup.WithContext(context.Background())
 
-	go func() {
-		produceErr <- spa.aprod.PublishMessages(ctx, acks, toSend)
-	}()
+	eg.Go(func() error {
+		return spa.aprod.PublishMessages(ctx, acks, toSend)
+	})
 
-	var needAcks []*produceReq
+	eg.Go(func() error {
+		var needAcks []*produceReq
+		defer func() {
+			// Send error to all waiting publish requests before shutting down
+			for _, req := range needAcks {
+				select {
+				case <-req.ctx.Done():
+				case req.done <- ErrSinkClosedDuringSend:
+				}
+			}
+		}()
 
-mainLoop:
-	for {
-		select {
-		case pr := <-spa.toProduce:
+		for {
 			select {
-			case toSend <- pr.m:
-				needAcks = append(needAcks, pr)
+			case <-ctx.Done():
+				return nil
+			case pr := <-spa.toProduce:
+				select {
+				case <-ctx.Done():
+					return nil
+				case toSend <- pr.m:
+					needAcks = append(needAcks, pr)
+				case <-spa.closeReq:
+					// Need to return error to stop the publisher
+					return errSinkClosed
+				}
+			case ack := <-acks:
+				if needAcks[0].m != ack {
+					panic("bug")
+				}
+				close(needAcks[0].done)
+				needAcks = needAcks[1:]
 			case <-spa.closeReq:
-				break mainLoop
+				// Need to return error to stop the publisher
+				return errSinkClosed
 			}
-		case ack := <-acks:
-			if needAcks[0].m != ack {
-				panic("bug")
-			}
-			close(needAcks[0].done)
-			needAcks = needAcks[1:]
-		case <-spa.closeReq:
-			break mainLoop
 		}
-	}
+	})
 
-	cancel()
-	spa.closeErr = <-produceErr
-	if spa.closeErr == context.Canceled {
+	spa.closeErr = eg.Wait()
+	if spa.closeErr == errSinkClosed {
 		spa.closeErr = nil
 	}
 	close(spa.closed)
@@ -84,7 +109,7 @@ mainLoop:
 func (spa *synchronousMessageSinkAdapter) Close() error {
 	select {
 	case <-spa.closed:
-		return errors.New("SynchronousMessageSinkAdapter is already closed")
+		return ErrSinkAlreadyClosed
 	case spa.closeReq <- struct{}{}:
 		<-spa.closed
 		aCloseErr := spa.aprod.Close()
@@ -96,16 +121,18 @@ func (spa *synchronousMessageSinkAdapter) Close() error {
 }
 
 func (spa *synchronousMessageSinkAdapter) PublishMessage(ctx context.Context, m Message) error {
-	pr := &produceReq{m, make(chan struct{}), ctx}
+	pr := &produceReq{m, make(chan error), ctx}
 
 	select {
 	case spa.toProduce <- pr:
 		select {
-		case <-pr.done:
-			return nil
+		case err := <-pr.done:
+			return err
 		case <-ctx.Done():
 			return ctx.Err()
 		}
+	case <-spa.closed:
+		return ErrSinkAlreadyClosed
 	case <-ctx.Done():
 		return ctx.Err()
 	}

--- a/sync_adapter_sink_test.go
+++ b/sync_adapter_sink_test.go
@@ -48,7 +48,8 @@ func TestSyncProduceAdapter_ErrorOnSend(t *testing.T) {
 	msg := message([]byte{'t'})
 
 	assert.Equal(t, ErrSinkClosedDuringSend, sc.PublishMessage(ctx, &msg))
-	assert.Equal(t, errSeenAllMessages, sc.(*synchronousMessageSinkAdapter).closeErr)
+	assert.Equal(t, errSeenAllMessages, sc.Close())
+	assert.Equal(t, ErrSinkAlreadyClosed, sc.Close())
 }
 
 var errSeenAllMessages = errors.New("mock sink saw specified number of messages")

--- a/sync_adapter_sink_test.go
+++ b/sync_adapter_sink_test.go
@@ -47,7 +47,7 @@ func TestSyncProduceAdapter_ErrorOnSend(t *testing.T) {
 
 	msg := message([]byte{'t'})
 
-	assert.Equal(t, ErrSinkClosedDuringSend, sc.PublishMessage(ctx, &msg))
+	assert.Equal(t, ErrSinkClosedOrFailedDuringSend, sc.PublishMessage(ctx, &msg))
 	assert.Equal(t, errSeenAllMessages, sc.Close())
 	assert.Equal(t, ErrSinkAlreadyClosed, sc.Close())
 }


### PR DESCRIPTION
Similarly as I did for the source I refactored the synchronous message sink using error group, what simplifies the logic. I've also slightly changed the behaviour of the publish method which now returns meaningful error to the client when sink is closed or when we fail to send the message.