### PR TITLE
Add offset to nats streaming implementation.

### DIFF
--- a/natsstreaming/nats_streaming.go
+++ b/natsstreaming/nats_streaming.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/nats-io/go-nats-streaming"
-	"github.com/nats-io/go-nats-streaming/pb"
 	"github.com/uw-labs/substrate"
 )
 
@@ -18,7 +17,14 @@ var (
 	_ substrate.AsyncMessageSource = (*asyncMessageSource)(nil)
 )
 
-// AsyncMessageSinkConfig is the configarion parameters for an
+const (
+	// OffsetOldest indicates the oldest appropriate message available on the broker.
+	OffsetOldest int64 = -2
+	// OffsetNewest indicates the next appropriate message available on the broker.
+	OffsetNewest int64 = -1
+)
+
+// AsyncMessageSinkConfig is the configuration parameters for an
 // AsyncMessageSink.
 type AsyncMessageSinkConfig struct {
 	URL       string
@@ -145,6 +151,7 @@ type AsyncMessageSourceConfig struct {
 	QueueGroup  string
 	MaxInFlight int
 	AckWait     time.Duration
+	Offset      int64
 }
 
 type asyncMessageSource struct {
@@ -157,6 +164,13 @@ func NewAsyncMessageSource(c AsyncMessageSourceConfig) (substrate.AsyncMessageSo
 	if clientID == "" {
 		clientID = c.QueueGroup + generateID()
 	}
+	switch {
+	case c.Offset == 0:
+		c.Offset = OffsetNewest
+	case c.Offset < -2:
+		return nil, fmt.Errorf("invalid offset: '%v'", c.Offset)
+	}
+
 	conn, err := stan.Connect(c.ClusterID, clientID, stan.NatsURL(c.URL))
 	if err != nil {
 		return nil, err
@@ -194,12 +208,21 @@ func (c *asyncMessageSource) ConsumeMessages(ctx context.Context, messages chan<
 	if ackWait == 0 {
 		ackWait = stan.DefaultAckWait
 	}
+	var offsetOpt stan.SubscriptionOption
+	switch offset := c.conf.Offset; offset {
+	case OffsetOldest:
+		offsetOpt = stan.DeliverAllAvailable()
+	case OffsetNewest:
+		offsetOpt = stan.StartWithLastReceived()
+	default:
+		offsetOpt = stan.StartAtSequence(uint64(offset))
+	}
 
 	sub, err := c.conn.QueueSubscribe(
 		c.conf.Subject,
 		c.conf.QueueGroup,
 		f,
-		stan.StartAt(pb.StartPosition_First),
+		offsetOpt,
 		stan.DurableName(c.conf.QueueGroup),
 		stan.SetManualAckMode(),
 		stan.AckWait(ackWait),

--- a/natsstreaming/nats_streaming_url.go
+++ b/natsstreaming/nats_streaming_url.go
@@ -54,6 +54,16 @@ func newNatsStreamingSource(u *url.URL) (substrate.AsyncMessageSource, error) {
 		Subject:    subject,
 	}
 
+	switch offset := q.Get("offset"); offset {
+	case "newest":
+		conf.Offset = OffsetNewest
+	case "oldest":
+		conf.Offset = OffsetOldest
+	case "":
+	default:
+		return nil, fmt.Errorf("unknown offset value '%s'", offset)
+	}
+
 	maxInflightString := q.Get("max-in-flight")
 	if maxInflightString != "" {
 		maxInflight, err := strconv.Atoi(maxInflightString)

--- a/natsstreaming/nats_streaming_url_test.go
+++ b/natsstreaming/nats_streaming_url_test.go
@@ -121,7 +121,7 @@ func TestNatsStreamingURLSource(t *testing.T) {
 		},
 		{
 			name:  "everything",
-			input: "nats-streaming://localhost:123/t1?cluster-id=cid1&client-id=clie1&queue-group=qg1&ack-wait=30s&max-in-flight=1234",
+			input: "nats-streaming://localhost:123/t1?cluster-id=cid1&client-id=clie1&queue-group=qg1&ack-wait=30s&max-in-flight=1234&offset=oldest",
 			expected: AsyncMessageSourceConfig{
 				URL:         "nats://localhost:123",
 				ClusterID:   "cid1",
@@ -130,6 +130,7 @@ func TestNatsStreamingURLSource(t *testing.T) {
 				Subject:     "t1",
 				AckWait:     30 * time.Second,
 				MaxInFlight: 1234,
+				Offset:      OffsetOldest,
 			},
 			expectedErr: false,
 		},


### PR DESCRIPTION
I also changed the default offset for NATS streaming to be the newest message to match the Kafka implementation. This change makes the two implementations consistent.

The code for parsing, the offset from the url can be abstracted, but I will leave this for another PR.