### PR TITLE
Pass acknowledgments in a select in the instrumented handler.

### DIFF
--- a/instrumented/sink.go
+++ b/instrumented/sink.go
@@ -50,7 +50,11 @@ func (ams *AsyncMessageSink) PublishMessages(ctx context.Context, acks chan<- su
 		select {
 		case success := <-successes:
 			ams.counter.WithLabelValues("success", ams.topic).Inc()
-			acks <- success
+			select {
+			case acks <- success:
+			case <-ctx.Done():
+				return <-errs
+			}
 		case <-ctx.Done():
 			return <-errs
 		case err := <-errs:

--- a/instrumented/source.go
+++ b/instrumented/source.go
@@ -47,7 +47,11 @@ func (ams *AsyncMessageSource) ConsumeMessages(ctx context.Context, messages cha
 	for {
 		select {
 		case ack := <-acks:
-			toBeAcked <- ack
+			select {
+			case toBeAcked <- ack:
+			case <-ctx.Done():
+				return <-errs
+			}
 			ams.counter.WithLabelValues("success", ams.topic).Inc()
 		case <-ctx.Done():
 			return <-errs


### PR DESCRIPTION
This is to avoid deadlock, when the context is cancelled after receiving the acknowledgement.