### PR TITLE
Fix nats status check

### DIFF
--- a/natsstreaming/status.go
+++ b/natsstreaming/status.go
@@ -1,31 +1,28 @@
 package natsstreaming
 
 import (
-	"errors"
 	"fmt"
 
 	nats "github.com/nats-io/go-nats"
 	"github.com/uw-labs/substrate"
 )
 
-// ErrNotConnected is returned if a status is requested before the connection has been initialized
-var ErrNotConnected = errors.New("nats not connected")
-
 func natsStatus(nc *nats.Conn) (*substrate.Status, error) {
 	if nc == nil {
-		return nil, ErrNotConnected
+		return &substrate.Status{
+			Problems: []string{"no nats connection"},
+			Working:  false,
+		}, nil
 	}
-	working := nc.IsConnected()
-	var problems []string
-	if !working {
-		notConnected := ErrNotConnected.Error()
-		if lastErr := nc.LastError(); lastErr != nil {
-			notConnected = fmt.Sprintf("%s - last error: %s", notConnected, lastErr.Error())
-		}
-		problems = append(problems, notConnected)
+
+	if nc.IsConnected() {
+		return &substrate.Status{
+			Working: true,
+		}, nil
 	}
+
 	return &substrate.Status{
-		Problems: problems,
-		Working:  working,
+		Problems: []string{fmt.Sprintf("nats not connected - last error: %v", lastErr)},
+		Working:  false,
 	}, nil
 }


### PR DESCRIPTION
There were previously two code paths that indicated in some way that
nats was not connected. One was that the connection was nil, and the
other that the connection was not nil, but IsConnected returned false.
The former returned an error, and the latter returned a non-working
status.

This is not useful to the caller who is expecting an error only if we
cannot establish the status.

Rework and simplify the code so that we always return a status object
(and no error) if we can establish that there is no connection.

Note that returning an error here should only happen if we fail to
establish whether or not things are working, which is actually not
something that ever happens for the nats check, given how the nats api
works.