### PR TITLE
Use run group instead of error group

### DIFF
--- a/internal/testshared/testshared.go
+++ b/internal/testshared/testshared.go
@@ -225,7 +225,7 @@ func testPublisherShouldNotBlock(t *testing.T, ts TestServer) {
 		testMessages = append(testMessages, &m)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	prod := ts.NewProducer(topic)
 

--- a/proximo/proximo_sink.go
+++ b/proximo/proximo_sink.go
@@ -65,6 +65,8 @@ func (ams *asyncMessageSink) PublishMessages(ctx context.Context, acks chan<- su
 	proximoAcks := make(chan string)
 
 	rg.Go(func() error {
+		defer stream.CloseSend()
+
 		return ams.sendMessagesToProximo(ctx, stream, messages, toAck)
 	})
 	rg.Go(func() error {

--- a/proximo/proximo_sink.go
+++ b/proximo/proximo_sink.go
@@ -12,8 +12,8 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/uw-labs/proximo/proximoc-go"
-	"github.com/uw-labs/rungroup"
 	"github.com/uw-labs/substrate"
+	"github.com/uw-labs/sync/rungroup"
 )
 
 var _ substrate.AsyncMessageSink = (*asyncMessageSink)(nil)

--- a/proximo/proximo_source.go
+++ b/proximo/proximo_source.go
@@ -83,7 +83,7 @@ func (cm *consMsg) getMsgID() string {
 
 func (ams *asyncMessageSource) ConsumeMessages(ctx context.Context, messages chan<- substrate.Message, acks <-chan substrate.Message) error {
 
-	eg, ctx := rungroup.New(ctx)
+	rg, ctx := rungroup.New(ctx)
 	client := proximoc.NewMessageSourceClient(ams.conn)
 
 	stream, err := client.Consume(ctx)
@@ -103,7 +103,7 @@ func (ams *asyncMessageSource) ConsumeMessages(ctx context.Context, messages cha
 
 	toAck := make(chan *consMsg)
 
-	eg.Go(func() error {
+	rg.Go(func() error {
 		var toAckList []*consMsg
 		for {
 			select {
@@ -131,7 +131,7 @@ func (ams *asyncMessageSource) ConsumeMessages(ctx context.Context, messages cha
 		}
 	})
 
-	eg.Go(func() error {
+	rg.Go(func() error {
 		for {
 			in, err := stream.Recv()
 			if err != nil {
@@ -155,7 +155,7 @@ func (ams *asyncMessageSource) ConsumeMessages(ctx context.Context, messages cha
 		}
 	})
 
-	return eg.Wait()
+	return rg.Wait()
 
 }
 

--- a/proximo/proximo_source.go
+++ b/proximo/proximo_source.go
@@ -90,7 +90,6 @@ func (ams *asyncMessageSource) ConsumeMessages(ctx context.Context, messages cha
 	if err != nil {
 		return errors.Wrap(err, "fail to consume")
 	}
-	defer stream.CloseSend()
 
 	if err := stream.Send(&proximoc.ConsumerRequest{
 		StartRequest: &proximoc.StartConsumeRequest{
@@ -104,6 +103,8 @@ func (ams *asyncMessageSource) ConsumeMessages(ctx context.Context, messages cha
 	toAck := make(chan *consMsg)
 
 	rg.Go(func() error {
+		defer stream.CloseSend()
+
 		var toAckList []*consMsg
 		for {
 			select {

--- a/proximo/proximo_source.go
+++ b/proximo/proximo_source.go
@@ -10,8 +10,8 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/uw-labs/proximo/proximoc-go"
-	"github.com/uw-labs/rungroup"
 	"github.com/uw-labs/substrate"
+	"github.com/uw-labs/sync/rungroup"
 )
 
 const (


### PR DESCRIPTION
This makes sure that the clients terminate as soon as one of the parts does. It also removes the need to control the flow using custom errors.

I also cleaned up the usage of the deprecated `grpc.Code` function.