### PR TITLE
feat: Keep Alive for proximo clients

### DIFF
--- a/proximo/doc.go
+++ b/proximo/doc.go
@@ -12,7 +12,9 @@
 //
 // Additionally, for sources, the following url parameters are available
 //
-//      offset           - The initial offset. Valid values are `newest` and `oldest`.
-//      consumer-group   - The consumer group id
+//      offset             - The initial offset. Valid values are `newest` and `oldest`.
+//      consumer-group     - The consumer group id
+//      keep-alive-time    - The interval that a keep alive is performed at as a go duration
+//      keep-alive-timeout - The go duration at which a keepalive will timeout [Default: 10s] (requires keep-alive-time to take effect, if keep-alive-time is not present this is ignored)
 //
 package proximo

--- a/proximo/proximo.go
+++ b/proximo/proximo.go
@@ -14,8 +14,11 @@ import (
 	"github.com/uw-labs/substrate"
 )
 
+// KeepAlive provides configuration for the gRPC keep alive
 type KeepAlive struct {
-	Time    time.Duration
+	// Time the interval at which a keep alive is performed
+	Time time.Duration
+	// TimeOut the duration in which a keep alive is deemed to have failed if no response is received
 	Timeout time.Duration
 }
 

--- a/proximo/proximo.go
+++ b/proximo/proximo.go
@@ -2,6 +2,9 @@ package proximo
 
 import (
 	"crypto/tls"
+	"time"
+
+	"google.golang.org/grpc/keepalive"
 
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
@@ -11,8 +14,21 @@ import (
 	"github.com/uw-labs/substrate"
 )
 
-func dialProximo(broker string, insecure bool) (*grpc.ClientConn, error) {
+type KeepAlive struct {
+	Time    time.Duration
+	Timeout time.Duration
+}
+
+func dialProximo(broker string, insecure bool, ka *KeepAlive) (*grpc.ClientConn, error) {
 	var opts []grpc.DialOption
+
+	if ka != nil {
+		opts = append(opts, grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			Time:    ka.Time,
+			Timeout: ka.Timeout,
+		}))
+	}
+
 	if insecure {
 		opts = append(opts, grpc.WithInsecure())
 	} else {

--- a/proximo/proximo_sink.go
+++ b/proximo/proximo_sink.go
@@ -19,14 +19,15 @@ import (
 var _ substrate.AsyncMessageSink = (*asyncMessageSink)(nil)
 
 type AsyncMessageSinkConfig struct {
-	Broker   string
-	Topic    string
-	Insecure bool
+	Broker    string
+	Topic     string
+	Insecure  bool
+	KeepAlive *KeepAlive
 }
 
 func NewAsyncMessageSink(c AsyncMessageSinkConfig) (substrate.AsyncMessageSink, error) {
 
-	conn, err := dialProximo(c.Broker, c.Insecure)
+	conn, err := dialProximo(c.Broker, c.Insecure, c.KeepAlive)
 	if err != nil {
 		return nil, err
 	}

--- a/proximo/proximo_source.go
+++ b/proximo/proximo_source.go
@@ -36,11 +36,12 @@ type AsyncMessageSourceConfig struct {
 	Broker        string
 	Offset        Offset
 	Insecure      bool
+	KeepAlive     *KeepAlive
 }
 
 func NewAsyncMessageSource(c AsyncMessageSourceConfig) (substrate.AsyncMessageSource, error) {
 
-	conn, err := dialProximo(c.Broker, c.Insecure)
+	conn, err := dialProximo(c.Broker, c.Insecure, c.KeepAlive)
 	if err != nil {
 		return nil, err
 	}

--- a/proximo/proximo_url.go
+++ b/proximo/proximo_url.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/uw-labs/substrate"
 	"github.com/uw-labs/substrate/suburl"
@@ -26,6 +27,29 @@ func newProximoSink(u *url.URL) (substrate.AsyncMessageSink, error) {
 	conf := AsyncMessageSinkConfig{
 		Broker: u.Host,
 		Topic:  topic,
+	}
+
+	if q.Get("keep-alive-time") != "" {
+
+		t, err := time.ParseDuration(q.Get("keep-alive-time"))
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse keep-alive-time: %s", q.Get("keep-alive-time"))
+		}
+
+		ka := &KeepAlive{
+			Time:    t,
+			Timeout: time.Second * 10,
+		}
+
+		if q.Get("keep-alive-timeout") != "" {
+			to, err := time.ParseDuration(q.Get("keep-alive-timeout"))
+			if err != nil {
+				return nil, fmt.Errorf("unable to parse keep-alive-timeout: %s", q.Get("keep-alive-timeout"))
+			}
+			ka.Timeout = to
+		}
+
+		conf.KeepAlive = ka
 	}
 
 	switch q.Get("insecure") {
@@ -55,6 +79,29 @@ func newProximoSource(u *url.URL) (substrate.AsyncMessageSource, error) {
 		Broker:        u.Host,
 		ConsumerGroup: q.Get("consumer-group"),
 		Topic:         topic,
+	}
+
+	if q.Get("keep-alive-time") != "" {
+
+		t, err := time.ParseDuration(q.Get("keep-alive-time"))
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse keep-alive-time: %s", q.Get("keep-alive-time"))
+		}
+
+		ka := &KeepAlive{
+			Time:    t,
+			Timeout: time.Second * 10,
+		}
+
+		if q.Get("keep-alive-timeout") != "" {
+			to, err := time.ParseDuration(q.Get("keep-alive-timeout"))
+			if err != nil {
+				return nil, fmt.Errorf("unable to parse keep-alive-timeout: %s", q.Get("keep-alive-timeout"))
+			}
+			ka.Timeout = to
+		}
+
+		conf.KeepAlive = ka
 	}
 
 	switch q.Get("insecure") {

--- a/proximo/proximo_url_test.go
+++ b/proximo/proximo_url_test.go
@@ -2,6 +2,7 @@ package proximo
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/uw-labs/substrate"
@@ -34,6 +35,30 @@ func TestProximoSink(t *testing.T) {
 				Topic:  "t1",
 			},
 			expectedErr: nil,
+		},
+		{
+			name:  "with-keep-alive",
+			input: "proximo://localhost:123/t1?keep-alive-time=60m",
+			expected: AsyncMessageSinkConfig{
+				Broker: "localhost:123",
+				Topic:  "t1",
+				KeepAlive: &KeepAlive{
+					Time:    time.Minute * 60,
+					Timeout: time.Second * 10,
+				},
+			},
+		},
+		{
+			name:  "with-keep-alive-timeout",
+			input: "proximo://localhost:123/t1?keep-alive-time=60m&keep-alive-timeout=70s",
+			expected: AsyncMessageSinkConfig{
+				Broker: "localhost:123",
+				Topic:  "t1",
+				KeepAlive: &KeepAlive{
+					Time:    time.Minute * 60,
+					Timeout: time.Second * 70,
+				},
+			},
 		},
 		{
 			name:  "insecure",
@@ -102,6 +127,30 @@ func TestProximoSource(t *testing.T) {
 				Insecure: true,
 			},
 			expectedErr: nil,
+		},
+		{
+			name:  "with-keep-alive",
+			input: "proximo://localhost:123/t1?keep-alive-time=60m",
+			expected: AsyncMessageSourceConfig{
+				Broker: "localhost:123",
+				Topic:  "t1",
+				KeepAlive: &KeepAlive{
+					Time:    time.Minute * 60,
+					Timeout: time.Second * 10,
+				},
+			},
+		},
+		{
+			name:  "with-keep-alive-timeout",
+			input: "proximo://localhost:123/t1?keep-alive-time=60m&keep-alive-timeout=70s",
+			expected: AsyncMessageSourceConfig{
+				Broker: "localhost:123",
+				Topic:  "t1",
+				KeepAlive: &KeepAlive{
+					Time:    time.Minute * 60,
+					Timeout: time.Second * 70,
+				},
+			},
 		},
 		{
 			name:  "everything",


### PR DESCRIPTION
Provides the ability for you to configure keep alive for
proximo clients that consume from a proximo server providing
keep alive functionality