### PR TITLE
Fix deadlock in instrumented wrappers

### DIFF
--- a/instrumented/sink.go
+++ b/instrumented/sink.go
@@ -54,6 +54,11 @@ func (ams *AsyncMessageSink) PublishMessages(ctx context.Context, acks chan<- su
 			case acks <- success:
 			case <-ctx.Done():
 				return <-errs
+			case err := <-errs:
+				if err != nil {
+					ams.counter.WithLabelValues("error", ams.topic).Inc()
+				}
+				return err
 			}
 		case <-ctx.Done():
 			return <-errs

--- a/instrumented/source.go
+++ b/instrumented/source.go
@@ -51,6 +51,11 @@ func (ams *AsyncMessageSource) ConsumeMessages(ctx context.Context, messages cha
 			case toBeAcked <- ack:
 			case <-ctx.Done():
 				return <-errs
+			case err := <-errs:
+				if err != nil {
+					ams.counter.WithLabelValues("error", ams.topic).Inc()
+				}
+				return err
 			}
 			ams.counter.WithLabelValues("success", ams.topic).Inc()
 		case <-ctx.Done():

--- a/instrumented/source_test.go
+++ b/instrumented/source_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
@@ -67,7 +68,7 @@ func TestConsumeMessagesSuccessfully(t *testing.T) {
 			return
 		case <-receivedAcks:
 			var metric dto.Metric
-			source.counter.WithLabelValues("success", "testTopic").Write(&metric)
+			assert.NoError(t, source.counter.WithLabelValues("success", "testTopic").Write(&metric))
 			assert.Equal(t, 1, int(*metric.Counter.Value))
 
 			sourceCancel()
@@ -109,8 +110,66 @@ func TestConsumeMessagesWithError(t *testing.T) {
 	assert.Equal(t, consumingErr, err)
 
 	var metric dto.Metric
-	source.counter.WithLabelValues("error", "testTopic").Write(&metric)
+	assert.NoError(t, source.counter.WithLabelValues("error", "testTopic").Write(&metric))
 	assert.Equal(t, 1, int(*metric.Counter.Value))
 
 	sourceCancel()
+}
+
+func TestConsumeOnBackendShutdown(t *testing.T) {
+	expectedErr := errors.New("shutdown")
+	backendCtx, backendCancel := context.WithCancel(context.Background())
+
+	source := AsyncMessageSource{
+		impl: &asyncMessageSourceMock{
+			consumerMessagesMock: func(ctx context.Context, messages chan<- substrate.Message, acks <-chan substrate.Message) error {
+				select {
+				case <-ctx.Done():
+					return nil
+				case <-backendCtx.Done():
+					return expectedErr
+				}
+			},
+		},
+		counter: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Help: "source_counter",
+				Name: "source_counter",
+			}, []string{"status", "topic"}),
+		topic: "testTopic",
+	}
+
+	acks := make(chan substrate.Message)
+	messages := make(chan substrate.Message)
+
+	sourceContext, sourceCancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer sourceCancel()
+
+	errs := make(chan error)
+	go func() {
+		defer close(errs)
+		errs <- source.ConsumeMessages(sourceContext, messages, acks)
+	}()
+
+	// Writer acknowledgement
+	select {
+	case <-sourceContext.Done():
+		t.Fatalf("Failed to write acknowledgement.")
+	case acks <- Message{}:
+	}
+
+	// Shutdown backend
+	backendCancel()
+
+	// Check wrapper shuts down properly
+	select {
+	case <-sourceContext.Done():
+		t.Fatalf("Wrapper failed to shutdown.")
+	case err := <-errs:
+		assert.Equal(t, expectedErr, err)
+		// Check metric was increased
+		var metric dto.Metric
+		assert.NoError(t, source.counter.WithLabelValues("error", "testTopic").Write(&metric))
+		assert.Equal(t, 1, int(*metric.Counter.Value))
+	}
 }


### PR DESCRIPTION
 The deadlock happens when trying to acknowledge a message when the backend has already terminated.