### PR TITLE
Rehydration mechanism

### DIFF
--- a/freezer/freezer.go
+++ b/freezer/freezer.go
@@ -115,7 +115,7 @@ type asyncMessageSource struct {
 	fms *freezer.MessageSource
 }
 
-func (ams *asyncMessageSource) ConsumeMessages(ctx context.Context, messages chan<- substrate.Message, acks <-chan substrate.Message) error {
+func (ams *asyncMessageSource) ConsumeMessages(ctx context.Context, messages chan<- substrate.Message, acks <-chan substrate.Message, opts ...substrate.Option) error {
 
 	eg, ctx := errgroup.WithContext(ctx)
 

--- a/instrumented/source.go
+++ b/instrumented/source.go
@@ -35,7 +35,7 @@ func NewAsyncMessageSource(source substrate.AsyncMessageSource, counterOpts prom
 }
 
 // ConsumeMessages implements message consuming wrapped in instrumentation
-func (ams *AsyncMessageSource) ConsumeMessages(ctx context.Context, messages chan<- substrate.Message, acks <-chan substrate.Message) error {
+func (ams *AsyncMessageSource) ConsumeMessages(ctx context.Context, messages chan<- substrate.Message, acks <-chan substrate.Message, opts ...substrate.Option) error {
 	toBeAcked := make(chan substrate.Message, cap(acks))
 
 	errs := make(chan error)

--- a/instrumented/source_test.go
+++ b/instrumented/source_test.go
@@ -17,7 +17,7 @@ type asyncMessageSourceMock struct {
 	consumerMessagesMock func(context.Context, chan<- substrate.Message, <-chan substrate.Message) error
 }
 
-func (m asyncMessageSourceMock) ConsumeMessages(ctx context.Context, in chan<- substrate.Message, acks <-chan substrate.Message) error {
+func (m asyncMessageSourceMock) ConsumeMessages(ctx context.Context, in chan<- substrate.Message, acks <-chan substrate.Message, opts ...substrate.Option) error {
 	return m.consumerMessagesMock(ctx, in, acks)
 }
 

--- a/kafka/kafka.go
+++ b/kafka/kafka.go
@@ -230,7 +230,7 @@ func (cm *consumerMessage) DiscardPayload() {
 	cm.cm = nil
 }
 
-func (ams *asyncMessageSource) ConsumeMessages(ctx context.Context, messages chan<- substrate.Message, acks <-chan substrate.Message) error {
+func (ams *asyncMessageSource) ConsumeMessages(ctx context.Context, messages chan<- substrate.Message, acks <-chan substrate.Message, opts ...substrate.Option) error {
 
 	c, err := cluster.NewConsumerFromClient(ams.client, ams.consumerGroup, []string{ams.topic})
 	if err != nil {

--- a/options.go
+++ b/options.go
@@ -1,0 +1,49 @@
+package substrate
+
+import "context"
+
+// Option aggregates the client options
+type Option interface {
+	apply(*funcOption)
+	WithRehydration() (bool, context.Context, chan<- struct{})
+}
+
+type funcOption struct {
+	f                  func(*funcOption)
+	rehydration        bool
+	rehydrationContext context.Context
+	rehydrationChannel chan<- struct{}
+}
+
+func (fdo *funcOption) WithRehydration() (bool, context.Context, chan<- struct{}) {
+	return fdo.rehydration, fdo.rehydrationContext, fdo.rehydrationChannel
+}
+
+func (fdo *funcOption) apply(do *funcOption) {
+	fdo.f(do)
+}
+
+func newFuncOption(f func(*funcOption)) *funcOption {
+	return &funcOption{
+		f: f,
+	}
+}
+
+// ParseOptions parse the given options and mutate the options structure
+func ParseOptions(opts ...Option) Option {
+	o := new(funcOption)
+	for _, opt := range opts {
+		opt.apply(o)
+	}
+	return o
+}
+
+// WithRehydration is used while rehydrating an aggregate based on a stream of events.
+// Once the rehydration is done (the latest sequence is reached), a notification is sent to the provided channel.
+func WithRehydration(ctx context.Context, rehydrated chan<- struct{}) Option {
+	return newFuncOption(func(options *funcOption) {
+		options.rehydration = true
+		options.rehydrationContext = ctx
+		options.rehydrationChannel = rehydrated
+	})
+}

--- a/proximo/proximo_source.go
+++ b/proximo/proximo_source.go
@@ -87,7 +87,7 @@ func (cm *consMsg) getMsgID() string {
 	return cm.id
 }
 
-func (ams *asyncMessageSource) ConsumeMessages(ctx context.Context, messages chan<- substrate.Message, acks <-chan substrate.Message) error {
+func (ams *asyncMessageSource) ConsumeMessages(ctx context.Context, messages chan<- substrate.Message, acks <-chan substrate.Message, opts ...substrate.Option) error {
 
 	rg, ctx := rungroup.New(ctx)
 	client := proto.NewMessageSourceClient(ams.conn)

--- a/substrate.go
+++ b/substrate.go
@@ -46,7 +46,7 @@ type AsyncMessageSource interface {
 	// channel and expects them to be sent back to the `acks` channel once
 	// that have been handled properly.  This function will block until
 	// `ctx` is done, or until an error occurs.
-	ConsumeMessages(ctx context.Context, messages chan<- Message, acks <-chan Message) error
+	ConsumeMessages(ctx context.Context, messages chan<- Message, acks <-chan Message, opts ...Option) error
 	// Close permanently closes the AsyncMessageSource and frees underlying resources
 	Close() error
 	Statuser

--- a/sync_adapter_source_test.go
+++ b/sync_adapter_source_test.go
@@ -121,7 +121,7 @@ type mockAsyncSource struct {
 	closed chan struct{}
 }
 
-func (mock *mockAsyncSource) ConsumeMessages(ctx context.Context, messages chan<- Message, acks <-chan Message) error {
+func (mock *mockAsyncSource) ConsumeMessages(ctx context.Context, messages chan<- Message, acks <-chan Message, opts ...Option) error {
 	for {
 		select {
 		case <-ctx.Done():


### PR DESCRIPTION
I'm gonna try to explain the purpose of this PR by describing my use case first.

In Unicom, we have a service that must compute an internal **state** based on the events from a NATS queue. We could simply create a substrate client from the oldest offset and compute our internal state.

Yet, there's a limitation with this approach. There is no way to catch the **exact moment** where the state is built (i.e. when all the events from the queue have been caught so that our internal state computation is finished). Hence, if we receive a request while we are still reading from the queue, this might end up in an **inconsistent** response.

My proposition is to implement a way for the client to get **notified** once we have read all the current events from the queue.

First, I introduce the concept of dynamic options. For example, a client can call substrate like this:
```go
timeout, cancel := context.WithTimeout(context.Background(), duration)
ch := make(chan struct{})
err := asyncSource.ConsumeMessages(groupCtx, messageChan, ackChan, substrate.WithRehydration(timeout, ch))
```

Here, once the latest event is caught, it will trigger a notification to the provided channel.

This way, as a substrate client, I can set up my **service readiness** once and only once I receive this notification. Then, I can keep my subscription alive to get notified of future events that will have an impact on my state.

Note: this PR is **backward compatible**