### PR TITLE
Configurable max receive message size

### DIFF
--- a/proximo/doc.go
+++ b/proximo/doc.go
@@ -17,5 +17,6 @@
 //      keep-alive-time    - The interval that a keep alive is performed at as a go duration
 //      keep-alive-timeout - The go duration at which a keepalive will timeout [Default: 10s] (requires keep-alive-time to take effect, if keep-alive-time is not present this is ignored)
 //      insecure=true      - The connection to the proximo grpc endpoint will not be using TLS
+//      max-recv-msg-size  - The gRPC max receive message size in bytes (source only) [Default: 67,108,864 (64MiB)]
 //
 package proximo

--- a/proximo/proximo_sink.go
+++ b/proximo/proximo_sink.go
@@ -27,7 +27,11 @@ type AsyncMessageSinkConfig struct {
 
 func NewAsyncMessageSink(c AsyncMessageSinkConfig) (substrate.AsyncMessageSink, error) {
 
-	conn, err := dialProximo(c.Broker, c.Insecure, c.KeepAlive)
+	conn, err := dialProximo(dialConfig{
+		broker:    c.Broker,
+		insecure:  c.Insecure,
+		keepAlive: c.KeepAlive,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/proximo/proximo_source.go
+++ b/proximo/proximo_source.go
@@ -31,17 +31,23 @@ var (
 // AsyncMessageSource represents a proximo message source and implements the
 // substrate.AsyncMessageSource interface.
 type AsyncMessageSourceConfig struct {
-	ConsumerGroup string
-	Topic         string
-	Broker        string
-	Offset        Offset
-	Insecure      bool
-	KeepAlive     *KeepAlive
+	ConsumerGroup  string
+	Topic          string
+	Broker         string
+	Offset         Offset
+	Insecure       bool
+	KeepAlive      *KeepAlive
+	MaxRecvMsgSize int
 }
 
 func NewAsyncMessageSource(c AsyncMessageSourceConfig) (substrate.AsyncMessageSource, error) {
 
-	conn, err := dialProximo(c.Broker, c.Insecure, c.KeepAlive)
+	conn, err := dialProximo(dialConfig{
+		broker:         c.Broker,
+		insecure:       c.Insecure,
+		keepAlive:      c.KeepAlive,
+		maxRecvMsgSize: c.MaxRecvMsgSize,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/proximo/proximo_url.go
+++ b/proximo/proximo_url.go
@@ -3,6 +3,7 @@ package proximo
 import (
 	"fmt"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -87,6 +88,14 @@ func newProximoSource(u *url.URL) (substrate.AsyncMessageSource, error) {
 	case "":
 	default:
 		return nil, fmt.Errorf("unknown offset value '%s'", q.Get("offset"))
+	}
+
+	if maxSize := q.Get("max-recv-msg-size"); maxSize != "" {
+		size, err := strconv.Atoi(maxSize)
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse max-recv-msg-size parameter: %s", err.Error())
+		}
+		conf.MaxRecvMsgSize = size
 	}
 
 	return proximoSourcer(conf)


### PR DESCRIPTION
We've published messages into kafka that exceed the 64MiB limit
here, so unfortunately this is leading to some services crashing.

Only making this available on the source config, as the sink case
doesn't _receive_ messages that are in any way bound to the size of
user supplied input.

Rather than adding another argument to dialProximo, I've wrapped
the arguments up in a struct. Hope that makes sense.

---

If this doesn't feel like it should be configurable we can also just set
it to `math.MaxInt32` - thoughts?