### PR TITLE
Fix Kafka partition key callback, when using synchronous wrapper

### DIFF
--- a/internal/unwrap/unwrap.go
+++ b/internal/unwrap/unwrap.go
@@ -10,6 +10,6 @@ func AnnotatedMessage(msg substrate.Message) substrate.Message {
 		if !ok {
 			return msg
 		}
-		msg = aMsg.OriginalMessage()
+		msg = aMsg.Original()
 	}
 }

--- a/internal/unwrap/unwrap.go
+++ b/internal/unwrap/unwrap.go
@@ -2,11 +2,20 @@ package unwrap
 
 import "github.com/uw-labs/substrate"
 
-// AnnotatedMessage is a convenience function that unwraps a chain of annotated messages
+// AnnotatedMessage is an interface implemented by messages used by sink wrappers,
+// in particular the synchronous sink adapter. This allows the backends to retrieve
+// the original message the user sent when invoking user provided callbacks for example
+// for getting partition keys.
+type AnnotatedMessage interface {
+	substrate.Message
+	Original() substrate.Message
+}
+
+// Unwrap is a convenience function that unwraps a chain of annotated messages
 // and returns the original one.
-func AnnotatedMessage(msg substrate.Message) substrate.Message {
+func Unwrap(msg substrate.Message) substrate.Message {
 	for {
-		aMsg, ok := msg.(substrate.AnnotatedMessage)
+		aMsg, ok := msg.(AnnotatedMessage)
 		if !ok {
 			return msg
 		}

--- a/internal/unwrap/unwrap.go
+++ b/internal/unwrap/unwrap.go
@@ -1,0 +1,15 @@
+package unwrap
+
+import "github.com/uw-labs/substrate"
+
+// AnnotatedMessage is a convenience function that unwraps a chain of annotated messages
+// and returns the original one.
+func AnnotatedMessage(msg substrate.Message) substrate.Message {
+	for {
+		aMsg, ok := msg.(substrate.AnnotatedMessage)
+		if !ok {
+			return msg
+		}
+		msg = aMsg.OriginalMessage()
+	}
+}

--- a/internal/unwrap/unwrap_test.go
+++ b/internal/unwrap/unwrap_test.go
@@ -45,6 +45,6 @@ func (msg *annotatedMessage) Data() []byte {
 	return msg.original.Data()
 }
 
-func (msg *annotatedMessage) OriginalMessage() substrate.Message {
+func (msg *annotatedMessage) Original() substrate.Message {
 	return msg.original
 }

--- a/internal/unwrap/unwrap_test.go
+++ b/internal/unwrap/unwrap_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/uw-labs/substrate/internal/unwrap"
 )
 
-func TestAnnotatedMessage(t *testing.T) {
+func TestUnwrap(t *testing.T) {
 	originalMsg := &message{
 		data: []byte("data"),
 	}
@@ -23,7 +23,7 @@ func TestAnnotatedMessage(t *testing.T) {
 			},
 		},
 	}
-	unwrappedMsg := unwrap.AnnotatedMessage(wrappedMsg)
+	unwrappedMsg := unwrap.Unwrap(wrappedMsg)
 
 	require.Equal(t, originalMsg, unwrappedMsg)
 }

--- a/internal/unwrap/unwrap_test.go
+++ b/internal/unwrap/unwrap_test.go
@@ -1,0 +1,50 @@
+package unwrap_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/uw-labs/substrate"
+	"github.com/uw-labs/substrate/internal/unwrap"
+)
+
+func TestAnnotatedMessage(t *testing.T) {
+	originalMsg := &message{
+		data: []byte("data"),
+	}
+	wrappedMsg := &annotatedMessage{
+		annotation: 1,
+		original: &annotatedMessage{
+			annotation: 2,
+			original: &annotatedMessage{
+				annotation: 3,
+				original:   originalMsg,
+			},
+		},
+	}
+	unwrappedMsg := unwrap.AnnotatedMessage(wrappedMsg)
+
+	require.Equal(t, originalMsg, unwrappedMsg)
+}
+
+type message struct {
+	data []byte
+}
+
+func (msg *message) Data() []byte {
+	return msg.data
+}
+
+type annotatedMessage struct {
+	annotation int
+	original   substrate.Message
+}
+
+func (msg *annotatedMessage) Data() []byte {
+	return msg.original.Data()
+}
+
+func (msg *annotatedMessage) OriginalMessage() substrate.Message {
+	return msg.original
+}

--- a/kafka/kafka.go
+++ b/kafka/kafka.go
@@ -97,7 +97,7 @@ func (ams *asyncMessageSink) doPublishMessages(ctx context.Context, producer sar
 
 			if ams.KeyFunc != nil {
 				// Provide original user message to the partition key function.
-				unwrappedMsg := unwrap.AnnotatedMessage(m)
+				unwrappedMsg := unwrap.Unwrap(m)
 				message.Key = sarama.ByteEncoder(ams.KeyFunc(unwrappedMsg))
 			}
 

--- a/kafka/kafka.go
+++ b/kafka/kafka.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Shopify/sarama"
 	cluster "github.com/bsm/sarama-cluster"
 	"github.com/uw-labs/substrate"
+	"github.com/uw-labs/substrate/internal/unwrap"
 )
 
 var (
@@ -95,7 +96,9 @@ func (ams *asyncMessageSink) doPublishMessages(ctx context.Context, producer sar
 			message.Value = sarama.ByteEncoder(m.Data())
 
 			if ams.KeyFunc != nil {
-				message.Key = sarama.ByteEncoder(ams.KeyFunc(m))
+				// Provide original user message to the partition key function.
+				unwrappedMsg := unwrap.AnnotatedMessage(m)
+				message.Key = sarama.ByteEncoder(ams.KeyFunc(unwrappedMsg))
 			}
 
 			message.Metadata = m

--- a/substrate.go
+++ b/substrate.go
@@ -23,15 +23,6 @@ type DiscardableMessage interface {
 	DiscardPayload()
 }
 
-// AnnotatedMessage is an interface implemented by messages used by sink wrappers,
-// in particular the synchronous sink adapter. This allows the backends to retrieve
-// the original message the user sent when invoking user provided callbacks for example
-// for getting partition keys.
-type AnnotatedMessage interface {
-	Message
-	Original() Message
-}
-
 // AsyncMessageSink represents a message sink that allows publishing messages,
 // and multiple messages can be in flight before any acks are recieved,
 // depending upon the configuration of the underlying message sink.

--- a/substrate.go
+++ b/substrate.go
@@ -23,6 +23,15 @@ type DiscardableMessage interface {
 	DiscardPayload()
 }
 
+// AnnotatedMessage is an interface implemented by messages used by sink wrappers,
+// in particular the synchronous sink adapter. This allows the backends to retrieve
+// the original message the user sent when invoking user provided callbacks for example
+// for getting partition keys.
+type AnnotatedMessage interface {
+	Message
+	OriginalMessage() Message
+}
+
 // AsyncMessageSink represents a message sink that allows publishing messages,
 // and multiple messages can be in flight before any acks are recieved,
 // depending upon the configuration of the underlying message sink.

--- a/substrate.go
+++ b/substrate.go
@@ -29,7 +29,7 @@ type DiscardableMessage interface {
 // for getting partition keys.
 type AnnotatedMessage interface {
 	Message
-	OriginalMessage() Message
+	Original() Message
 }
 
 // AsyncMessageSink represents a message sink that allows publishing messages,

--- a/sync_adapter_sink.go
+++ b/sync_adapter_sink.go
@@ -166,6 +166,6 @@ type seqMessage struct {
 	Message
 }
 
-func (msg seqMessage) OriginalMessage() Message {
+func (msg seqMessage) Original() Message {
 	return msg.Message
 }

--- a/sync_adapter_sink.go
+++ b/sync_adapter_sink.go
@@ -165,3 +165,7 @@ type seqMessage struct {
 	seq int
 	Message
 }
+
+func (msg seqMessage) OriginalMessage() Message {
+	return msg.Message
+}


### PR DESCRIPTION
Currently when using synchronous adapter and Kafka we can't easily retrieve partition key from the substrate message, as the callback is called with an annotated one. With this change the user will receive the message they originally provided. We can potentially make the `AnnotatedMessage` interface private, but it will make implementing additional sink wrappers outside of the package easier.