### PR TITLE
Restart Kafka consumer after rebalance.

### DIFF
--- a/kafka/integration_test.go
+++ b/kafka/integration_test.go
@@ -3,8 +3,6 @@ package kafka
 import (
 	"bytes"
 	"context"
-	"crypto/rand"
-	"encoding/hex"
 	"fmt"
 	"os/exec"
 	"strconv"
@@ -14,6 +12,7 @@ import (
 
 	"github.com/Shopify/sarama"
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
 	"github.com/uw-labs/substrate"
 	"github.com/uw-labs/substrate/internal/testshared"
 )
@@ -27,6 +26,9 @@ func TestAll(t *testing.T) {
 
 	defer k.Kill()
 
+	t.Run("Kafka Rebalance", func(t *testing.T) {
+		k.testRebalance(t)
+	})
 	testshared.TestAll(t, k)
 }
 
@@ -35,9 +37,97 @@ type testServer struct {
 	port          int
 }
 
+func (ks *testServer) brokers() []string {
+	return []string{fmt.Sprintf("127.0.0.1:%d", ks.port)}
+}
+
+func (ks *testServer) testRebalance(t *testing.T) {
+	cfg := sarama.NewConfig()
+	cfg.Version = sarama.V2_4_0_0
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*2)
+	defer cancel()
+	admin, err := sarama.NewClusterAdmin(ks.brokers(), cfg)
+	require.NoError(t, err)
+
+	topic := "rebalancing-test"
+	consumerGroup := "group-consumers"
+	require.NoError(t, admin.CreateTopic(topic, &sarama.TopicDetail{
+		NumPartitions:     6,
+		ReplicationFactor: 1,
+	}, false))
+
+	var expectedMsgs []string
+	c1Err, c2Err := make(chan error, 1), make(chan error, 1)
+	c1Msgs, c2Msgs := map[string]bool{}, map[string]bool{}
+
+	c1Ctx, c1Cancel := context.WithCancel(ctx)
+	go func() {
+		c1 := substrate.NewSynchronousMessageSource(ks.NewConsumer(topic, consumerGroup))
+		defer func() { require.NoError(t, c1.Close()) }()
+
+		c1Err <- c1.ConsumeMessages(c1Ctx, func(_ context.Context, msg substrate.Message) error {
+			c1Msgs[string(msg.Data())] = true
+			return nil
+		})
+	}()
+
+	p := substrate.NewSynchronousMessageSink(ks.NewProducer(topic))
+	defer func() { require.NoError(t, p.Close()) }()
+	for i := 0; i < 5; i++ {
+		payload := fmt.Sprintf("message-%v", i)
+		expectedMsgs = append(expectedMsgs, payload)
+		require.NoError(t, p.PublishMessage(ctx, &message{data: []byte(payload)}))
+	}
+	time.Sleep(time.Second * 5) // Sleep to read some messages.
+
+	c2Ctx, c2Cancel := context.WithCancel(ctx)
+	go func() {
+		c2 := substrate.NewSynchronousMessageSource(ks.NewConsumer(topic, consumerGroup))
+		defer func() { require.NoError(t, c2.Close()) }()
+
+		c2Err <- c2.ConsumeMessages(c2Ctx, func(_ context.Context, msg substrate.Message) error {
+			c2Msgs[string(msg.Data())] = true
+			return nil
+		})
+	}()
+	time.Sleep(time.Second * 20) // Sleep to wait for rebalance.
+
+	for i := 5; i < 10; i++ {
+		payload := fmt.Sprintf("message-%v", i)
+		expectedMsgs = append(expectedMsgs, payload)
+		require.NoError(t, p.PublishMessage(ctx, &message{data: []byte(payload)}))
+	}
+	time.Sleep(time.Second * 5) // Sleep to read some messages.
+	c1Cancel()
+	time.Sleep(time.Second * 20) // Sleep to wait for rebalance.
+
+	for i := 10; i < 15; i++ {
+		payload := fmt.Sprintf("message-%v", i)
+		expectedMsgs = append(expectedMsgs, payload)
+		require.NoError(t, p.PublishMessage(ctx, &message{data: []byte(payload)}))
+	}
+	time.Sleep(time.Second * 5) // Sleep to read all remaining messages.
+	c2Cancel()
+
+	require.NoError(t, <-c1Err)
+	require.NoError(t, <-c2Err)
+
+	var actualMsgs []string
+	for msg := range c1Msgs {
+		actualMsgs = append(actualMsgs, msg)
+	}
+	for msg := range c2Msgs {
+		if !c1Msgs[msg] {
+			actualMsgs = append(actualMsgs, msg)
+		}
+	}
+	require.ElementsMatch(t, expectedMsgs, actualMsgs)
+}
+
 func (ks *testServer) NewConsumer(topic string, groupID string) substrate.AsyncMessageSource {
 	s, err := NewAsyncMessageSource(AsyncMessageSourceConfig{
-		Brokers:       []string{fmt.Sprintf("localhost:%d", ks.port)},
+		Brokers:       ks.brokers(),
 		ConsumerGroup: groupID,
 		Topic:         topic,
 		Offset:        OffsetOldest,
@@ -52,7 +142,7 @@ func (ks *testServer) NewConsumer(topic string, groupID string) substrate.AsyncM
 
 func (ks *testServer) NewProducer(topic string) substrate.AsyncMessageSink {
 	s, err := NewAsyncMessageSink(AsyncMessageSinkConfig{
-		Brokers: []string{fmt.Sprintf("localhost:%d", ks.port)},
+		Brokers: ks.brokers(),
 		Topic:   topic,
 	})
 	if err != nil {
@@ -140,11 +230,10 @@ loop2:
 	return ks, nil
 }
 
-func generateID() string {
-	random := []byte{0, 0, 0, 0, 0, 0, 0, 0}
-	_, err := rand.Read(random)
-	if err != nil {
-		panic(err)
-	}
-	return hex.EncodeToString(random)
+type message struct {
+	data []byte
+}
+
+func (msg *message) Data() []byte {
+	return msg.data
 }


### PR DESCRIPTION
We were not handling rebalances correctly when there were multiple consumers in a group. This fixes that and adds a test that triggers 2 rebalances to ensure correct behaviour.