### PR TITLE
Fix bug causing compile error

### DIFF
--- a/kafka/kafka_url.go
+++ b/kafka/kafka_url.go
@@ -31,7 +31,7 @@ func newKafkaSink(u *url.URL) (substrate.AsyncMessageSink, error) {
 
 	conf.Brokers = append(conf.Brokers, q["broker"]...)
 
-	conf.Version := q.Get("version")
+	conf.Version = q.Get("version")
 
 	return kafkaSinker(conf)
 }
@@ -74,8 +74,8 @@ func newKafkaSource(u *url.URL) (substrate.AsyncMessageSource, error) {
 		conf.MetadataRefreshFrequency = d
 	}
 
-	conf.Version := q.Get("version")
-	
+	conf.Version = q.Get("version")
+
 	return kafkaSourcer(conf)
 }
 


### PR DESCRIPTION
Invalid assignment using `:=` to set a field on the config struct

Oops

Does make me wonder what `GolangCI` is actually doing - looks like it raised warnings caused by not being able to compile, but still reported all checks were successful