### PR TITLE
Make Kafka consumer session timeout configurable.

### DIFF
--- a/kafka/kafka.go
+++ b/kafka/kafka.go
@@ -24,6 +24,7 @@ const (
 	OffsetNewest int64 = sarama.OffsetNewest
 
 	defaultMetadataRefreshFrequency = 10 * time.Minute
+	defaultConsumerSessionTimeout   = 10 * time.Second
 )
 
 type AsyncMessageSinkConfig struct {
@@ -162,6 +163,7 @@ type AsyncMessageSourceConfig struct {
 	Offset                   int64
 	MetadataRefreshFrequency time.Duration
 	OffsetsRetention         time.Duration
+	SessionTimeout           time.Duration
 	Version                  string
 }
 
@@ -174,11 +176,16 @@ func (ams *AsyncMessageSourceConfig) buildSaramaConsumerConfig() (*sarama.Config
 	if ams.MetadataRefreshFrequency > 0 {
 		mrf = ams.MetadataRefreshFrequency
 	}
+	st := defaultConsumerSessionTimeout
+	if ams.SessionTimeout != 0 {
+		st = ams.SessionTimeout
+	}
 
 	config := sarama.NewConfig()
 	config.Consumer.Return.Errors = true
 	config.Consumer.Offsets.Initial = offset
 	config.Metadata.RefreshFrequency = mrf
+	config.Consumer.Group.Session.Timeout = st
 	config.Consumer.Offsets.Retention = ams.OffsetsRetention
 
 	if ams.Version != "" {

--- a/kafka/kafka_url.go
+++ b/kafka/kafka_url.go
@@ -73,6 +73,14 @@ func newKafkaSource(u *url.URL) (substrate.AsyncMessageSource, error) {
 		}
 		conf.MetadataRefreshFrequency = d
 	}
+	dur = q.Get("session-timeout")
+	if dur != "" {
+		d, err := time.ParseDuration(dur)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse session timeout : %v", err)
+		}
+		conf.SessionTimeout = d
+	}
 
 	conf.Version = q.Get("version")
 

--- a/kafka/kafka_url_test.go
+++ b/kafka/kafka_url_test.go
@@ -123,11 +123,12 @@ func TestKafkaSource(t *testing.T) {
 		},
 		{
 			name:  "everything",
-			input: "kafka://localhost:123/t1/?offset=newest&consumer-group=g1&metadata-refresh=2s&broker=localhost:234&broker=localhost:345&version=0.10.2.0",
+			input: "kafka://localhost:123/t1/?offset=newest&consumer-group=g1&metadata-refresh=2s&broker=localhost:234&broker=localhost:345&version=0.10.2.0&session-timeout=30s",
 			expected: AsyncMessageSourceConfig{
 				Brokers:                  []string{"localhost:123", "localhost:234", "localhost:345"},
 				ConsumerGroup:            "g1",
 				MetadataRefreshFrequency: 2 * time.Second,
+				SessionTimeout:           30 * time.Second,
 				Offset:                   sarama.OffsetNewest,
 				Topic:                    "t1",
 				Version:                  "0.10.2.0",


### PR DESCRIPTION
The motivation for this is that the default in the old
sarama cluster library was 30s, wheres the new implementation
uses 10s. We stared seeing timeouts after the migration, so
we want to be able to increase the timeout as appropriate.