### PR TITLE
Update freezer for zstd compression

### DIFF
--- a/freezer/freezer_url.go
+++ b/freezer/freezer_url.go
@@ -29,6 +29,8 @@ func newFreezerSink(u *url.URL) (substrate.AsyncMessageSink, error) {
 	switch cts {
 	case "snappy":
 		ct = freezer.CompressionTypeSnappy
+	case "zstd":
+		ct = freezer.CompressionTypeZstd
 	case "none", "":
 	default:
 		return nil, fmt.Errorf("unknown compression type : %s", cts)
@@ -102,6 +104,8 @@ func newFreezerSource(u *url.URL) (substrate.AsyncMessageSource, error) {
 	switch cts {
 	case "snappy":
 		ct = freezer.CompressionTypeSnappy
+	case "zstd":
+		ct = freezer.CompressionTypeZstd
 	case "none", "":
 	default:
 		return nil, fmt.Errorf("unknown compression type : %s", cts)

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4
 	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.4.0
-	github.com/uw-labs/freezer v0.0.0-20200217144949-6d67e7edcab8
+	github.com/uw-labs/freezer v0.0.0-20200401091355-8c3c14c85532
 	github.com/uw-labs/proximo v0.0.0-20190913093050-8229af78f5dd
 	github.com/uw-labs/straw v0.0.0-20200213162553-01e9a0f94f69
 	github.com/uw-labs/sync v0.0.0-20190307114256-1bb306bf6e71

--- a/go.sum
+++ b/go.sum
@@ -160,6 +160,8 @@ github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvW
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.9.7 h1:hYW1gP94JUmAhBtJ+LNz5My+gBobDxPR1iVuKug26aA=
 github.com/klauspost/compress v1.9.7/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
+github.com/klauspost/compress v1.10.3 h1:OP96hzwJVBIHYU52pVTI6CczrxPvrGfgqF9N5eTO0Q8=
+github.com/klauspost/compress v1.10.3/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
@@ -255,8 +257,8 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
-github.com/uw-labs/freezer v0.0.0-20200217144949-6d67e7edcab8 h1:Q7qMe+CluY56heRODKHQm2G3z7/0/wzxXdRFXshFMc4=
-github.com/uw-labs/freezer v0.0.0-20200217144949-6d67e7edcab8/go.mod h1:fVLLU+8tXbrr5AH4p6rlHsHu2p5u8VpbtnHkBHSiuFo=
+github.com/uw-labs/freezer v0.0.0-20200401091355-8c3c14c85532 h1:hoqPd5dqQDzX4n2zT+JqBhOKOu7aadtfIz1w5MZZVEw=
+github.com/uw-labs/freezer v0.0.0-20200401091355-8c3c14c85532/go.mod h1:vCVqxiFSuGMpo3Tf6oFjeokGK0TuzwGHIFQJndlr0iA=
 github.com/uw-labs/proximo v0.0.0-20190913093050-8229af78f5dd h1:rEvgmQoJk1MxPhv0aVIyOB/NKMtbAzsEJcmL/d/vpUU=
 github.com/uw-labs/proximo v0.0.0-20190913093050-8229af78f5dd/go.mod h1:qvhJ61jBx9RI4vrThNU4jroHCMpbU850pzmm+1b4fYk=
 github.com/uw-labs/straw v0.0.0-20200213162553-01e9a0f94f69 h1:qinD550PpJ3cEoYSsD60bZlO6LA603e5xGKqFOjGqq4=


### PR DESCRIPTION
Update freezer to get zstd compression & change the freezer backend to
expose zstd in suburl.