### PR TITLE
Fix potential shutdown deadlock

### DIFF
--- a/kafka/producer.go
+++ b/kafka/producer.go
@@ -102,7 +102,11 @@ func (ams *asyncMessageSink) doPublishMessages(ctx context.Context, producer sar
 			}
 
 			message.Metadata = m
-			input <- message
+			select {
+			case input <- message:
+			case <-ctx.Done():
+				return nil
+			}
 			ams.debugger.Logf("substrate : sent to kafka : %s\n", m)
 		case <-ctx.Done():
 			return nil


### PR DESCRIPTION
Ensure we can never get blocked on sending a message to sarama when
sarama is no longer listening because we're shutting down.