### PR TITLE
RefreshMetadata in Kafka status check

### DIFF
--- a/kafka/status.go
+++ b/kafka/status.go
@@ -8,6 +8,13 @@ import (
 func status(client sarama.Client, topic string) (*substrate.Status, error) {
 	status := &substrate.Status{}
 
+	err := client.RefreshMetadata(topic)
+	if err != nil {
+		status.Working = false
+		status.Problems = append(status.Problems, err.Error())
+		return status, nil
+	}
+
 	writablePartitions, err := client.WritablePartitions(topic)
 	if err != nil {
 		status.Working = false
@@ -17,6 +24,18 @@ func status(client sarama.Client, topic string) (*substrate.Status, error) {
 	if len(writablePartitions) == 0 {
 		status.Working = false
 		status.Problems = append(status.Problems, "no writable partitions")
+		return status, nil
+	}
+
+	partitions, err := client.Partitions(topic)
+	if err != nil {
+		status.Working = false
+		status.Problems = append(status.Problems, err.Error())
+		return status, nil
+	}
+	if len(writablePartitions) < len(partitions) {
+		status.Working = true
+		status.Problems = append(status.Problems, "some partitions are leaderless")
 		return status, nil
 	}
 


### PR DESCRIPTION
Calls too `WritablePartitions` use a cached result, when brokers
become unavailable this would still return the cached result set
therefore the status would never become unhealthy.

This now calls `RefreshMetadata` to ensure connectvity to brokers
is still available

Also adds extra checks for leaderless partitions