### PR TITLE
Expand error message

### DIFF
--- a/kafka/consumer_group_handler.go
+++ b/kafka/consumer_group_handler.go
@@ -101,7 +101,7 @@ func (ap *kafkaAcksProcessor) run(ctx context.Context) error {
 			case ap.sess = <-ap.sessCh:
 			}
 		case msg := <-ap.fromKafka:
-			ap.debugger.Logf("substrate : got message from kafka : %s\n", msg)
+			ap.debugger.Logf("substrate : consumer - got message from kafka : %s\n", msg)
 			if err := ap.processMessage(ctx, msg); err != nil {
 				if err == context.Canceled {
 					// This error is returned when a context cancellation is encountered
@@ -141,11 +141,11 @@ func (ap *kafkaAcksProcessor) processMessage(ctx context.Context, msg *consumerM
 			}
 			return nil // We can return immediately as the current message can be discarded.
 		case ap.toClient <- msg:
-			ap.debugger.Logf("substrate : sent message to caller : %s\n", pl)
+			ap.debugger.Logf("substrate : consumer - sent message to caller : %s\n", pl)
 			ap.forAcking = append(ap.forAcking, msg)
 			return nil // We have passed the message to the client, so we can exit this loop.
 		case ack := <-ap.acks:
-			ap.debugger.Logf("substrate : got ack from caller for message : %s\n", msg)
+			ap.debugger.Logf("substrate : consumer - got ack from caller for message : %s\n", msg)
 			// Still process acks, so that we don't block the consumer acknowledging the message.
 			if err := ap.processAck(ack); err != nil {
 				return err
@@ -173,14 +173,14 @@ func (ap *kafkaAcksProcessor) processAck(ack substrate.Message) error {
 		// Acknowledge the message.
 		if ap.forAcking[0].cm != nil {
 			ap.sess.MarkMessage(ap.forAcking[0].cm, "")
-			ap.debugger.Logf("substrate : sent ack to kafka for message : %s\n", ap.forAcking[0])
+			ap.debugger.Logf("substrate : consumer - sent ack to kafka for message : %s\n", ap.forAcking[0])
 		} else {
 			off := ap.forAcking[0].offset
 			// MarkOffset marks the next message to consume, so we need to add 1
 			// to the offset to mark this message as consumed. Note that the bsm cluster
 			// did this when committing offsets, so that's why it worked without this before.
 			ap.sess.MarkOffset(off.topic, off.partition, off.offset+1, "")
-			ap.debugger.Logf("substrate : sent ack to kafka for message : [payload not available]\n")
+			ap.debugger.Logf("substrate : consumer - sent ack to kafka for message : [payload not available]\n")
 		}
 		ap.forAcking = ap.forAcking[1:]
 	}

--- a/kafka/producer.go
+++ b/kafka/producer.go
@@ -86,7 +86,7 @@ func (ams *asyncMessageSink) doPublishMessages(ctx context.Context, producer sar
 				msg := suc.Metadata.(substrate.Message)
 				select {
 				case acks <- msg:
-					ams.debugger.Logf("substrate : sent ack to caller for message : %s\n", msg)
+					ams.debugger.Logf("substrate : producer - sent ack to caller for message : %s\n", msg)
 				case <-ctx.Done():
 					return ctx.Err()
 				}
@@ -118,7 +118,7 @@ func (ams *asyncMessageSink) doPublishMessages(ctx context.Context, producer sar
 				case <-ctx.Done():
 					return ctx.Err()
 				}
-				ams.debugger.Logf("substrate : sent to kafka : %s\n", m)
+				ams.debugger.Logf("substrate : producer - sent to kafka : %s\n", m)
 			case <-ctx.Done():
 				return ctx.Err()
 			case err := <-errs:


### PR DESCRIPTION
Expand error messages to include information about whether it's a
producer or consumer message.  This is obviously useful now, having
tried to debug things in production.