### PR TITLE
Add missing log message when debugging

### DIFF
--- a/kafka/consumer_group_handler.go
+++ b/kafka/consumer_group_handler.go
@@ -112,6 +112,7 @@ func (ap *kafkaAcksProcessor) run(ctx context.Context) error {
 				return err
 			}
 		case ack := <-ap.acks:
+			ap.debugger.Logf("substrate : consumer - got ack from caller for message : %s\n", ack)
 			if err := ap.processAck(ack); err != nil {
 				return err
 			}


### PR DESCRIPTION
There are two paths that lead to processing acks, we only logged on one
of them.  Ensure we log on both