### PR TITLE
Tweak debug for better performance

### DIFF
--- a/internal/debug/debug.go
+++ b/internal/debug/debug.go
@@ -24,6 +24,10 @@ func (d *Debugger) Logf(s string, args ...interface{}) {
 	if !d.Enabled {
 		return
 	}
+	d.doLogf(s, args)
+}
+
+func (d *Debugger) doLogf(s string, args ...interface{}) {
 	args1 := make([]interface{}, len(args))
 	for i, arg := range args {
 		switch a := arg.(type) {


### PR DESCRIPTION
Profiling showed significant time spend calling the LogF method, just to
return when debug is disabled.  This is because it's not getting
inlined.

This moves everything except the enabled check to another method, making
LogF simple enough that the compiler can now inline it.