### PR TITLE
Save memory in freezer source

### DIFF
--- a/freezer/freezer.go
+++ b/freezer/freezer.go
@@ -150,6 +150,7 @@ func (ams *asyncMessageSource) ConsumeMessages(ctx context.Context, messages cha
 						Expected: forAcking[0],
 					}
 				default:
+					forAcking[0].(*consumerMessage).data = nil // Allow data to be GC'd
 					forAcking = forAcking[1:]
 				}
 			case <-ctx.Done():


### PR DESCRIPTION
Once we have seen an ack for a messages, we discard it from the slice of
messages to ack. However, we do this by slicing the slice to remove the
first element.  This doesn't actually free the message from memory at
that point, so to prevent excessive memory use, also set the data in the
message to nil.