### PR TITLE
Expose Kafka metadata w/ Kafka-sourced messages

### DIFF
--- a/kafka/consumer.go
+++ b/kafka/consumer.go
@@ -122,6 +122,24 @@ func (cm *consumerMessage) Data() []byte {
 	return cm.cm.Value
 }
 
+type MessageWithMetadata interface {
+	GetMetadata() Metadata
+}
+
+type Metadata struct {
+	Topic     string
+	Partition int32
+	Offset    int64
+}
+
+func (cm *consumerMessage) GetMetadata() Metadata {
+	return Metadata{
+		Topic:     cm.offset.topic,
+		Partition: cm.offset.partition,
+		Offset:    cm.offset.offset,
+	}
+}
+
 func (cm *consumerMessage) DiscardPayload() {
 	if cm.offset != nil {
 		// already discarded

--- a/kafka/consumer.go
+++ b/kafka/consumer.go
@@ -133,10 +133,13 @@ type Metadata struct {
 }
 
 func (cm *consumerMessage) GetMetadata() Metadata {
+	if cm.cm == nil {
+		panic("GetMetadata: attempt to use payload after discarding.")
+	}
 	return Metadata{
-		Topic:     cm.offset.topic,
-		Partition: cm.offset.partition,
-		Offset:    cm.offset.offset,
+		Topic:     cm.cm.Topic,
+		Partition: cm.cm.Partition,
+		Offset:    cm.cm.Offset,
 	}
 }
 


### PR DESCRIPTION
Apologies if this idea has been discussed and rejected before. I feel like maybe it has. Or if there's already some other way to do this, and I just couldn't see it.

Intended usage:

```
offset := int64(-1)
if withMetadata, ok := msg.(kafka.MessageWithMetadata); ok {
	offset = withMetadata.GetMetadata().Offset
}
```