### PR TITLE
Return ctx.Err() where appropriate.

### DIFF
--- a/internal/helper/sink_ack_ordering.go
+++ b/internal/helper/sink_ack_ordering.go
@@ -79,10 +79,7 @@ func (s *AckOrderingSink) PublishMessages(ctx context.Context, acks chan<- subst
 		}
 	})
 
-	if err := eg.Wait(); err != nil && err != context.Canceled {
-		return err
-	}
-	return nil
+	return eg.Wait()
 }
 
 func contains(msgs map[substrate.Message]struct{}, msg substrate.Message) bool {

--- a/internal/helper/sink_ack_ordering_test.go
+++ b/internal/helper/sink_ack_ordering_test.go
@@ -45,7 +45,7 @@ func TestAckOrderingSink(t *testing.T) {
 	cancel()
 
 	err := eg.Wait()
-	assert.NoError(err)
+	assert.EqualError(err, "context canceled")
 }
 
 type myMessage struct {

--- a/internal/helper/sink_ack_ordering_test.go
+++ b/internal/helper/sink_ack_ordering_test.go
@@ -45,7 +45,7 @@ func TestAckOrderingSink(t *testing.T) {
 	cancel()
 
 	err := eg.Wait()
-	assert.EqualError(err, "context canceled")
+	assert.Equal(context.Canceled, err)
 }
 
 type myMessage struct {

--- a/internal/testshared/testshared.go
+++ b/internal/testshared/testshared.go
@@ -95,10 +95,10 @@ func testOnePublisherOneMessageOneConsumer(t *testing.T, ts TestServer) {
 
 	// we're done
 	cancel()
-	if err := <-consErrs; err != nil {
+	if err := <-consErrs; err != context.Canceled {
 		t.Errorf("unexpected error from consume : %s", err)
 	}
-	if err := <-prodErrs; err != nil {
+	if err := <-prodErrs; err != context.Canceled {
 		t.Errorf("unexpected error from produce : %s", err)
 	}
 }
@@ -127,7 +127,7 @@ func testOnePublisherOneConsumerConsumeWithoutAcking(t *testing.T, ts TestServer
 	produceAndCheckAck(prodCtx, t, prodMsgs, prodAcks, &m)
 	prodCancel()
 
-	if err := <-prodErrs; err != nil {
+	if err := <-prodErrs; err != context.Canceled {
 		t.Errorf("unexpected error from produce : %s", err)
 	}
 	if err := prod.Close(); err != nil {
@@ -146,7 +146,7 @@ func testOnePublisherOneConsumerConsumeWithoutAcking(t *testing.T, ts TestServer
 	m1 := <-cons1Msgs
 	assert.Equal(messageText, string(m1.Data()))
 	cons1Cancel()
-	if err := <-cons1Errs; err != nil {
+	if err := <-cons1Errs; err != context.Canceled {
 		t.Errorf("unexpected error from consume : %s", err)
 	}
 
@@ -163,7 +163,7 @@ func testOnePublisherOneConsumerConsumeWithoutAcking(t *testing.T, ts TestServer
 	assert.Equal(messageText, msgStr)
 
 	cons2Cancel()
-	if err := <-cons2Errs; err != nil {
+	if err := <-cons2Errs; err != context.Canceled {
 		t.Errorf("unexpected error from consume : %s", err)
 	}
 
@@ -210,7 +210,7 @@ func testOnePublisherOneMessageTwoConsumers(t *testing.T, ts TestServer) {
 
 	// we're done
 	cancel()
-	if err := <-cons1Errs; err != nil {
+	if err := <-cons1Errs; err != context.Canceled {
 		t.Errorf("unexpected error from consume : %s", err)
 	}
 }
@@ -365,7 +365,7 @@ func testConsumeWithoutAck(t *testing.T, ts TestServer) {
 	select {
 	case <-cons1Msgs:
 	case err := <-cons1Errs:
-		if err != nil {
+		if err != context.Canceled {
 			t.Error(err) // TODO: prolly not.
 		}
 	}
@@ -386,7 +386,7 @@ func testConsumeWithoutAck(t *testing.T, ts TestServer) {
 
 	// we're done
 	cancel()
-	if err := <-cons2Errs; err != nil {
+	if err := <-cons2Errs; err != context.Canceled {
 		t.Errorf("unexpected error from consume : %s", err)
 	}
 }
@@ -462,10 +462,10 @@ func testPublishMultipleMessagesOneConsumer(t *testing.T, ts TestServer) {
 
 	// we're done
 	cancel()
-	if err := <-consErrs; err != nil {
+	if err := <-consErrs; err != context.Canceled {
 		t.Errorf("unexpected error from consume : %s", err)
 	}
-	if err := <-prodErrs; err != nil {
+	if err := <-prodErrs; err != context.Canceled {
 		t.Errorf("unexpected error from produce : %s", err)
 	}
 }
@@ -494,7 +494,7 @@ func testOnePublisherOneConsumerConsumeWithoutAckingDiscardedPayload(t *testing.
 	produceAndCheckAck(prodCtx, t, prodMsgs, prodAcks, &m)
 	prodCancel()
 
-	if err := <-prodErrs; err != nil {
+	if err := <-prodErrs; err != context.Canceled {
 		t.Errorf("unexpected error from produce : %s", err)
 	}
 	if err := prod.Close(); err != nil {
@@ -513,7 +513,7 @@ func testOnePublisherOneConsumerConsumeWithoutAckingDiscardedPayload(t *testing.
 	m1 := <-cons1Msgs
 	assert.Equal(messageText, string(m1.Data()))
 	cons1Cancel()
-	if err := <-cons1Errs; err != nil {
+	if err := <-cons1Errs; err != context.Canceled {
 		t.Errorf("unexpected error from consume : %s", err)
 	}
 
@@ -530,7 +530,7 @@ func testOnePublisherOneConsumerConsumeWithoutAckingDiscardedPayload(t *testing.
 	assert.Equal(messageText, msgStr)
 
 	cons2Cancel()
-	if err := <-cons2Errs; err != nil {
+	if err := <-cons2Errs; err != context.Canceled {
 		t.Errorf("unexpected error from consume : %s", err)
 	}
 
@@ -554,7 +554,7 @@ func connectSendmessageAndClose(t *testing.T, ts TestServer, topic string, messa
 	message := testMessage([]byte(messageText))
 	produceAndCheckAck(ctx, t, prodMsgs, prodAcks, &message)
 	cancel()
-	if err := <-prodErrs; err != nil {
+	if err := <-prodErrs; err != context.Canceled {
 		t.Errorf("unexpected error from produce : %s", err)
 	}
 	if err := prod.Close(); err != nil {

--- a/kafka/consumer.go
+++ b/kafka/consumer.go
@@ -166,8 +166,11 @@ func (ams *asyncMessageSource) ConsumeMessages(ctx context.Context, messages cha
 				rebalanceCh: rebalanceCh,
 				debugger:    ams.debugger,
 			})
-			if err != nil || ctx.Err() != nil {
+			if err != nil {
 				return err
+			}
+			if ctx.Err() != nil {
+				return ctx.Err()
 			}
 		}
 	})

--- a/kafka/integration_test.go
+++ b/kafka/integration_test.go
@@ -109,8 +109,8 @@ func (ks *testServer) testRebalance(t *testing.T) {
 	time.Sleep(time.Second * 5) // Sleep to read all remaining messages.
 	c2Cancel()
 
-	require.NoError(t, <-c1Err)
-	require.NoError(t, <-c2Err)
+	require.Equal(t, context.Canceled, <-c1Err)
+	require.Equal(t, context.Canceled, <-c2Err)
 
 	var actualMsgs []string
 	for msg := range c1Msgs {

--- a/proximo/proximo_sink.go
+++ b/proximo/proximo_sink.go
@@ -111,7 +111,9 @@ func (ams *asyncMessageSink) sendMessagesToProximo(ctx context.Context, stream m
 			}
 			if err := stream.Send(&proto.PublisherRequest{Msg: pMsg}); err != nil {
 				if err == io.EOF || status.Code(err) == codes.Canceled {
-					return nil
+					if ctx.Err() != nil {
+						return ctx.Err()
+					}
 				}
 				return errors.Wrap(err, "failed to send message to proximo")
 			}
@@ -129,7 +131,9 @@ func (ams *asyncMessageSink) receiveAcksFromProximo(ctx context.Context, stream 
 		conf, err := stream.Recv()
 		if err != nil {
 			if err == io.EOF || status.Code(err) == codes.Canceled {
-				return nil
+				if ctx.Err() != nil {
+					return ctx.Err()
+				}
 			}
 			return errors.Wrap(err, "failed to receive acknowledgement")
 		}

--- a/proximo/proximo_sink.go
+++ b/proximo/proximo_sink.go
@@ -98,7 +98,7 @@ func (ams *asyncMessageSink) sendMessagesToProximo(ctx context.Context, stream m
 	for {
 		select {
 		case <-ctx.Done():
-			return nil
+			return ctx.Err()
 		case msg := <-messages:
 			pMsg := &proto.Message{
 				Id:   uuid.Must(uuid.NewV4()).String(),
@@ -106,7 +106,7 @@ func (ams *asyncMessageSink) sendMessagesToProximo(ctx context.Context, stream m
 			}
 			select {
 			case <-ctx.Done():
-				return nil
+				return ctx.Err()
 			case toAck <- &ackMessage{id: pMsg.Id, msg: msg}:
 			}
 			if err := stream.Send(&proto.PublisherRequest{Msg: pMsg}); err != nil {
@@ -135,7 +135,7 @@ func (ams *asyncMessageSink) receiveAcksFromProximo(ctx context.Context, stream 
 		}
 		select {
 		case <-ctx.Done():
-			return nil
+			return ctx.Err()
 		case proximoAcks <- conf.MsgID:
 			ams.debugger.Logf("substrate : got ack msgid from proximo %s\n", conf.MsgID)
 		}
@@ -147,7 +147,7 @@ func (ams *asyncMessageSink) passAcksToUser(ctx context.Context, acks chan<- sub
 	for {
 		select {
 		case <-ctx.Done():
-			return nil
+			return ctx.Err()
 		case ack := <-toAck:
 			ackMap[ack.id] = ack.msg
 		case msgID := <-proximoAcks:
@@ -159,7 +159,7 @@ func (ams *asyncMessageSink) passAcksToUser(ctx context.Context, acks chan<- sub
 			for !sent {
 				select {
 				case <-ctx.Done():
-					return nil
+					return ctx.Err()
 				case ack := <-toAck:
 					ackMap[ack.id] = ack.msg
 				case acks <- msg:

--- a/proximo/proximo_source.go
+++ b/proximo/proximo_source.go
@@ -142,7 +142,7 @@ func (ams *asyncMessageSource) ConsumeMessages(ctx context.Context, messages cha
 					toAckList = toAckList[1:]
 				}
 			case <-ctx.Done():
-				return nil
+				return ctx.Err()
 			}
 		}
 	})
@@ -161,12 +161,12 @@ func (ams *asyncMessageSource) ConsumeMessages(ctx context.Context, messages cha
 			select {
 			case toAck <- m:
 			case <-ctx.Done():
-				return nil
+				return ctx.Err()
 			}
 			select {
 			case messages <- m:
 			case <-ctx.Done():
-				return nil
+				return ctx.Err()
 			}
 		}
 	})

--- a/proximo/proximo_source.go
+++ b/proximo/proximo_source.go
@@ -135,7 +135,9 @@ func (ams *asyncMessageSource) ConsumeMessages(ctx context.Context, messages cha
 					id := toAckList[0].getMsgID()
 					if err := stream.Send(&proto.ConsumerRequest{Confirmation: &proto.Confirmation{MsgID: id}}); err != nil {
 						if err == io.EOF || status.Code(err) == codes.Canceled {
-							return nil
+							if ctx.Err() != nil {
+								return ctx.Err()
+							}
 						}
 						return err
 					}
@@ -152,7 +154,9 @@ func (ams *asyncMessageSource) ConsumeMessages(ctx context.Context, messages cha
 			in, err := stream.Recv()
 			if err != nil {
 				if err == io.EOF || status.Code(err) == codes.Canceled {
-					return nil
+					if ctx.Err() != nil {
+						return ctx.Err()
+					}
 				}
 				return err
 			}

--- a/substrate.go
+++ b/substrate.go
@@ -32,6 +32,8 @@ type AsyncMessageSink interface {
 	// been published.  This function will block until `ctx` is done,
 	// or until an error occurs.  Messages will always be processed
 	// and acknowledged in order.
+	// Normal termination is achieved when the passed Context is done,
+	// and will return the associated Context error.
 	PublishMessages(ctx context.Context, acks chan<- Message, messages <-chan Message) error
 	// Close permanently closes the AsyncMessageSink and frees underlying resources
 	Close() error
@@ -46,6 +48,8 @@ type AsyncMessageSource interface {
 	// channel and expects them to be sent back to the `acks` channel once
 	// that have been handled properly.  This function will block until
 	// `ctx` is done, or until an error occurs.
+	// Normal termination is achieved when the passed Context is done,
+	// and will return the associated Context error.
 	ConsumeMessages(ctx context.Context, messages chan<- Message, acks <-chan Message) error
 	// Close permanently closes the AsyncMessageSource and frees underlying resources
 	Close() error


### PR DESCRIPTION
If we are exiting because the context is done, return ctx.Err() to be
consistent with some of the other backends.

Note that this behaviour used to be in place (at least partly) but was
changed with commit cf052fc0

Updates #126