### PR TITLE
Extend Message to include Key

### DIFF
--- a/freezer/freezer.go
+++ b/freezer/freezer.go
@@ -199,3 +199,7 @@ type consumerMessage struct {
 func (cm *consumerMessage) Data() []byte {
 	return cm.data
 }
+
+func (cm *consumerMessage) Key() []byte {
+	return nil
+}

--- a/instrumented/sink_test.go
+++ b/instrumented/sink_test.go
@@ -29,6 +29,10 @@ func (m Message) Data() []byte {
 	return m.data
 }
 
+func (m Message) Key() []byte {
+	return nil
+}
+
 func TestPublishMessagesSuccessfully(t *testing.T) {
 	sink := AsyncMessageSink{
 		impl: &asyncMessageSinkMock{

--- a/internal/helper/sink_ack_ordering_test.go
+++ b/internal/helper/sink_ack_ordering_test.go
@@ -56,6 +56,10 @@ func (m *myMessage) Data() []byte {
 	return []byte{m.num}
 }
 
+func (m myMessage) Key() []byte {
+	return nil
+}
+
 type mockSink struct{}
 
 func (s *mockSink) Close() error {

--- a/internal/testshared/testshared.go
+++ b/internal/testshared/testshared.go
@@ -57,6 +57,10 @@ func (m *testMessage) Data() []byte {
 	return []byte(*m)
 }
 
+func (m testMessage) Key() []byte {
+	return nil
+}
+
 func testOnePublisherOneMessageOneConsumer(t *testing.T, ts TestServer) {
 	assert := assert.New(t)
 

--- a/internal/unwrap/unwrap_test.go
+++ b/internal/unwrap/unwrap_test.go
@@ -36,6 +36,10 @@ func (msg *message) Data() []byte {
 	return msg.data
 }
 
+func (msg message) Key() []byte {
+	return nil
+}
+
 type annotatedMessage struct {
 	annotation int
 	original   substrate.Message
@@ -43,6 +47,10 @@ type annotatedMessage struct {
 
 func (msg *annotatedMessage) Data() []byte {
 	return msg.original.Data()
+}
+
+func (msg annotatedMessage) Key() []byte {
+	return nil
 }
 
 func (msg *annotatedMessage) Original() substrate.Message {

--- a/kafka/consumer.go
+++ b/kafka/consumer.go
@@ -105,8 +105,7 @@ type asyncMessageSource struct {
 }
 
 type consumerMessage struct {
-	cm *sarama.ConsumerMessage
-
+	cm      *sarama.ConsumerMessage
 	discard bool
 	offset  *struct {
 		topic     string
@@ -120,6 +119,10 @@ func (cm *consumerMessage) Data() []byte {
 		panic("attempt to use payload after discarding.")
 	}
 	return cm.cm.Value
+}
+
+func (cm consumerMessage) Key() []byte {
+	return cm.cm.Key
 }
 
 func (cm *consumerMessage) DiscardPayload() {

--- a/kafka/integration_test.go
+++ b/kafka/integration_test.go
@@ -235,3 +235,7 @@ type message struct {
 func (msg *message) Data() []byte {
 	return msg.data
 }
+
+func (msg message) Key() []byte {
+	return nil
+}

--- a/natsstreaming/nats_streaming.go
+++ b/natsstreaming/nats_streaming.go
@@ -198,6 +198,10 @@ func (cm *consumerMessage) Data() []byte {
 	return cm.m.Data
 }
 
+func (cm *consumerMessage) Key() []byte {
+	return nil
+}
+
 func (c *asyncMessageSource) ConsumeMessages(ctx context.Context, messages chan<- substrate.Message, acks <-chan substrate.Message) error {
 	msgsToAck := make(chan *consumerMessage)
 

--- a/noop/noop_sink_test.go
+++ b/noop/noop_sink_test.go
@@ -17,6 +17,10 @@ func (m Message) Data() []byte {
 	return m.data
 }
 
+func (m Message) Key() []byte {
+	return nil
+}
+
 func TestPublishMessages(t *testing.T) {
 	sink := noop.NewAsyncMessageSink()
 	acks := make(chan substrate.Message)

--- a/proximo/proximo_source.go
+++ b/proximo/proximo_source.go
@@ -76,6 +76,10 @@ func (cm *consMsg) Data() []byte {
 	return cm.pm.Data
 }
 
+func (cm consMsg) Key() []byte {
+	return nil
+}
+
 func (cm *consMsg) DiscardPayload() {
 	if cm.pm != nil {
 		cm.id = cm.pm.GetId()

--- a/substrate.go
+++ b/substrate.go
@@ -8,6 +8,8 @@ import (
 // Message is the single type that represents all messages in substrate.
 type Message interface {
 	Data() []byte
+	// Key is used as the partition key for messages
+	Key() []byte
 }
 
 // DiscardableMessage allows a consumer to discard the payload after use (but

--- a/sync_adapter_source_test.go
+++ b/sync_adapter_source_test.go
@@ -15,6 +15,10 @@ func (m *message) Data() []byte {
 	return []byte(*m)
 }
 
+func (m message) Key() []byte {
+	return nil
+}
+
 func TestSyncConsumeAdapterBasic(t *testing.T) {
 	assert := assert.New(t)
 


### PR DESCRIPTION
This PR removes the `KeyFunc` found in the `kafka` sink config, and
replaces it with explicit partition config (mirroring sarama).
Additionally, it extends the `Message` interface to include a `Key()`
function allowing the client to specify it when they are sinking the
message. This way we can avoid the cost incurred by having to deserialize
every single message just to find out which key to use, and we can move
the key identification closer to the business logic, rather than the
initialization of a sink.

#### Cons

- Not all protocols have a concept of partitioning/key functions so
  having `Key` at the high level abstraction isn't the prettiest
- Having to explicitly configure the Hash Partitioner when using `Key`
  doesn't feel great.