### PR TITLE
Make freezer messages discardable

### DIFF
--- a/freezer/freezer.go
+++ b/freezer/freezer.go
@@ -197,5 +197,12 @@ type consumerMessage struct {
 }
 
 func (cm *consumerMessage) Data() []byte {
+	if cm.data == nil {
+		panic("attempt to use payload after discarding.")
+	}
 	return cm.data
+}
+
+func (cm *consumerMessage) DiscardPayload() {
+	cm.data = nil
 }


### PR DESCRIPTION
This makes freezer messages discardable to enable lower memory use in
consumers.