### PR TITLE
Add reference to substrate-tools for useful extenstions to substrate

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,7 @@ Current implementations and their status
 | Proximo                                  | alpha         |
 | Freezer                                  | alpha         |
 
+Additional resources
+----------------------------------------
+
+* [substrate-tools](https://github.com/uw-labs/substrate-tools) - Provides wrappers and packages that are useful for various tasks, such as acknowledgement ordering and instrumentation.


### PR DESCRIPTION
I've heard a few people mention that they didn't know about the existence of https://github.com/uw-labs/substrate-tools and have reinvented some existing, useful helpers.

Adding substrate-tools to the README as an additional resource means that we can more easily link the 2 for features that may not be suitable for substrate itself. That may also result in more pull requests landing at substrate-tools, instead of bloating the main package of substrate.

For the description of what substrate-tools is for, I wanted to keep it simple. If there was interest, we could include a summary of its relation to substrate as a destination for all the extra bells and whistles people may request.