### PR TITLE
Add noop source that blocks until the provided context is canceled.

### DIFF
--- a/noop/noop_sink.go
+++ b/noop/noop_sink.go
@@ -22,10 +22,10 @@ func (ams asyncMessageSink) PublishMessages(ctx context.Context, acks chan<- sub
 			select {
 			case acks <- msg:
 			case <-ctx.Done():
-				return nil
+				return ctx.Err()
 			}
 		case <-ctx.Done():
-			return nil
+			return ctx.Err()
 		}
 	}
 }

--- a/noop/noop_sink_test.go
+++ b/noop/noop_sink_test.go
@@ -25,7 +25,7 @@ func TestPublishMessages(t *testing.T) {
 	sinkContext, sinkCancel := context.WithCancel(context.Background())
 	defer sinkCancel()
 
-	errs := make(chan error)
+	errs := make(chan error, 1)
 
 	go func() {
 		defer close(errs)

--- a/noop/noop_source.go
+++ b/noop/noop_source.go
@@ -1,0 +1,33 @@
+package noop
+
+import (
+	"context"
+
+	"github.com/uw-labs/substrate"
+)
+
+// asyncMessageSource does no operations on publish messages calls
+type asyncMessageSource struct {
+	closed chan struct{}
+}
+
+// NewAsyncMessageSource returns a new AsyncMessageSource
+func NewAsyncMessageSource() substrate.AsyncMessageSource {
+	return &asyncMessageSource{}
+}
+
+// ConsumeMessages implements message consumption by blocking until the provided context is cancelled.
+func (ams asyncMessageSource) ConsumeMessages(ctx context.Context, _ chan<- substrate.Message, _ <-chan substrate.Message) error {
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+// Close closes the message source
+func (ams asyncMessageSource) Close() error {
+	return nil
+}
+
+// Status returns the status of this source (always working)
+func (ams asyncMessageSource) Status() (*substrate.Status, error) {
+	return &substrate.Status{Working: true}, nil
+}

--- a/noop/noop_source.go
+++ b/noop/noop_source.go
@@ -7,9 +7,7 @@ import (
 )
 
 // asyncMessageSource does no operations on publish messages calls
-type asyncMessageSource struct {
-	closed chan struct{}
-}
+type asyncMessageSource struct{}
 
 // NewAsyncMessageSource returns a new AsyncMessageSource
 func NewAsyncMessageSource() substrate.AsyncMessageSource {

--- a/noop/noop_url.go
+++ b/noop/noop_url.go
@@ -9,8 +9,13 @@ import (
 
 func init() {
 	suburl.RegisterSink("noop", newNoopSink)
+	suburl.RegisterSource("noop", newNoopSource)
 }
 
 func newNoopSink(u *url.URL) (substrate.AsyncMessageSink, error) {
 	return NewAsyncMessageSink(), nil
+}
+
+func newNoopSource(u *url.URL) (substrate.AsyncMessageSource, error) {
+	return NewAsyncMessageSource(), nil
 }


### PR DESCRIPTION
This is useful when we want to be able to easily disable consumption from one source.
We can use the noop reader and the service will behave as if no messages were coming in.

I have also updated the sink to return `ctx.Err()` instead of `nil` to make it match the
rest of the implementations.