### PR TITLE
Check for closed channel on sync sink status implementation

### DIFF
--- a/sync_adapter_sink.go
+++ b/sync_adapter_sink.go
@@ -156,7 +156,12 @@ func (spa *synchronousMessageSinkAdapter) PublishMessage(ctx context.Context, m 
 }
 
 func (spa *synchronousMessageSinkAdapter) Status() (*Status, error) {
-	return spa.aprod.Status()
+	select {
+	case <-spa.closed:
+		return &Status{Working: false, Problems: []string{"sink was closed"}}, nil
+	default:
+		return spa.aprod.Status()
+	}
 }
 
 type seqMessage struct {


### PR DESCRIPTION
This PR attempts to address an issue we've seen were a publisher might get stuck in a an endless loop of `sink was closed already` with the pod being reported as healthy.
I think the reason for this is that the `Status` implementation is missing a check on the `closed` channel. If an error happens while publishing for example because of the connection to kafka being lost, the channel will be closed and the producer will no longer be able to publish any messages because of this. But if the connection gets re-established the Status implementation will report `healthy`, as kafka is reachable and all, it's just our implementation that doesn't allow publishing messages because of the `closed` channel being already closed.