### PR TITLE
Set key only when non-nil

### DIFF
--- a/kafka/integration_test.go
+++ b/kafka/integration_test.go
@@ -191,6 +191,12 @@ loop:
 		switch {
 		case err == nil:
 			outS := string(out) // e.g., 0.0.0.0:32776
+
+			// Truncate any additional IPs after the first one
+			if i := strings.Index(outS, "\n"); i > -1 {
+				outS = outS[:i]
+			}
+
 			ps := strings.Split(outS, ":")
 			if len(ps) != 2 {
 				cmd.Process.Kill()
@@ -234,4 +240,8 @@ type message struct {
 
 func (msg *message) Data() []byte {
 	return msg.data
+}
+
+func (msg *message) Key() []byte {
+	return nil
 }

--- a/kafka/producer.go
+++ b/kafka/producer.go
@@ -115,7 +115,9 @@ func (ams *asyncMessageSink) doPublishMessages(ctx context.Context, producer sar
 				} else {
 					// No user specified key func, check for keyed message type
 					if km, ok := unwrappedMsg.(substrate.KeyedMessage); ok {
-						message.Key = sarama.ByteEncoder(km.Key())
+						if key := km.Key(); key != nil {
+							message.Key = sarama.ByteEncoder(key)
+						}
 					} else {
 						// Use the whole message as the hash key
 						message.Key = sarama.ByteEncoder(unwrappedMsg.Data())


### PR DESCRIPTION
I was investigating uneven message distribution across partitions in one of our services. We use a type that implements `KeyedMessage` but for this topic, we do not set a key by passing `nil`. I would have expected substrate to pass `nil` to Sarama and then for it fallback to using the random partitioner (https://github.com/Shopify/sarama/blob/v1.31.0/partitioner.go#L183-L185). However, we are passing the key directly to `sarama.ByteEncoder` which means we are passing an empty byte slice to Sarama/Kafka, thus getting the same hash each time (since `sarama.ProducerMessage.Key` is not null).

My Docker port command returns an IP6 address too, so in the test I've simply truncated that hence the change there too.